### PR TITLE
Fix Zero-Width Positioning

### DIFF
--- a/src/Content/Runtime/MessageTree.tsx
+++ b/src/Content/Runtime/MessageTree.tsx
@@ -1,8 +1,11 @@
 import { MessageRenderer } from 'src/Content/Runtime/MessageRenderer';
+import { EmoteStore } from 'src/Global/EmoteStore';
 import { Twitch } from 'src/Page/Util/Twitch';
 
 
 export class MessageTree {
+	previousEmote: EmoteStore.Emote | null = null;
+
 	constructor(private renderer: MessageRenderer) {
 
 	}
@@ -35,6 +38,7 @@ export class MessageTree {
 			parts.push(this.addPart(part));
 		}
 
+		this.previousEmote = null;
 		return parts;
 	}
 
@@ -86,6 +90,13 @@ export class MessageTree {
 		const emote = emoteStore.getEmote(emoteID);
 
 		if (!!emote) {
+			// If this emote is zerowidth, we must check the previous emote
+			if (emote.isZeroWidth() && !!this.previousEmote) {
+				// Previous emote should be the target for this zero-width emmote
+				// Add css class
+				this.previousEmote.element?.classList.add('seventv-next-is-zerowidth');
+			}
+			this.previousEmote = emote;
 			return emote.toElement(this.renderer.app.mainComponent?.getSetting('general.hide_unlisted_emotes').asBoolean());
 		}
 

--- a/src/Global/EmoteStore.tsx
+++ b/src/Global/EmoteStore.tsx
@@ -255,6 +255,7 @@ export namespace EmoteStore {
 		owner: Partial<DataStructure.TwitchUser> | null = null;
 		provider: DataStructure.Emote.Provider = '7TV';
 		urls = [] as [string, string][];
+		element: HTMLSpanElement | null = null;
 
 		constructor(private data: DataStructure.Emote) {
 			this.id = data.id ?? '';
@@ -362,7 +363,7 @@ export namespace EmoteStore {
 
 			inner.appendChild(img);
 			container.appendChild(inner);
-			return container;
+			return this.element = container;
 		}
 
 		resolve(): DataStructure.Emote {

--- a/src/Style/Style.scss
+++ b/src/Style/Style.scss
@@ -57,9 +57,12 @@ $accentColor: #b2ff59;
 }
 
 .seventv-emote.seventv-zerowidth {
-	width: 0px;
+	z-index: 50;
+}
+
+.seventv-emote.seventv-next-is-zerowidth {
 	position: absolute;
-	z-index: 1;
+	width: 0px;
 }
 
 .seventv-emote.seventv-emote-unlisted {


### PR DESCRIPTION
Changing how zero-width emotes render, by adding a css class to the emote preceding a zero-width emote. The previous method was causing a reversed order.