### PR TITLE
Rewrite emote menu button as function component

### DIFF
--- a/src/Sites/app/EmoteMenu/EmoteMenuButton.tsx
+++ b/src/Sites/app/EmoteMenu/EmoteMenuButton.tsx
@@ -1,42 +1,31 @@
 
 
-import React from 'react';
+import React, { useRef, MouseEvent } from 'react';
 import { MainComponent } from 'src/Sites/app/MainComponent';
 import { Logger } from 'src/Logger';
 import { assetStore } from 'src/Sites/app/SiteApp';
 
-export class EmoteMenuButton extends React.Component<EmoteMenuButton.Props> {
-	ref: React.RefObject<HTMLButtonElement>;
+export function EmoteMenuButton({ main, toSettings }: EmoteMenuButton.Props): JSX.Element {
+	const buttonRef = useRef<HTMLButtonElement>(null);
 
-	constructor(props: EmoteMenuButton.Props) {
-		super(props);
-
-		this.ref = React.createRef();
-	}
-
-	render() {
-		return (
-			<button ref={this.ref} title='7TV' onClick={ev => this.onClick(ev)} style={{ color: 'white' }}>
-				<img height={24} src={assetStore.get('7tv-nd.webp')} />
-			</button>
-		);
-	}
-
-	/**
-	 * Called when the user clicks the button
-	 */
-	private onClick(ev: React.MouseEvent): void {
-		ev.stopPropagation();
-		if (this.props.toSettings) {
+	const onClick = (e: MouseEvent): void => {
+		e.stopPropagation();
+		if (toSettings) {
 			Logger.Get().debug('EmoteMenuButton, action=onClick, to settings');
-			this.props.main?.openSettings();
+			main?.openSettings();
 			return undefined;
 		}
 
-		const bounds = this.ref.current?.getBoundingClientRect();
+		const bounds = buttonRef.current?.getBoundingClientRect();
 		Logger.Get().debug(`EmoteMenuButton, action=onClick, bounds=(x: ${bounds?.x}, y: ${bounds?.y})`);
-		this.props.main?.toggleEmoteMenu(bounds);
-	}
+		main?.toggleEmoteMenu(bounds);
+	};
+
+	return (
+		<button ref={buttonRef} title='7TV' onClick={onClick} style={{ color: 'white' }}>
+			<img height={24} src={assetStore.get('7tv-nd.webp')} />
+		</button>
+	);
 }
 
 export namespace EmoteMenuButton {


### PR DESCRIPTION
I'm not sure how open you are to contributions, but I like to suggest using more function components in your react code.
It's the defacto standard in react now. 

Classes will still be supported for now, but the future lies in function components and hooks.

https://reactjs.org/docs/hooks-intro.html

> We intend for Hooks to cover all existing use cases for classes, but we will keep supporting class components for the foreseeable future. At Facebook, we have tens of thousands of components written as classes, and we have absolutely no plans to rewrite them. Instead, we are starting to use Hooks in the new code side by side with classes.

Also I'm not  sure how I test this, I got as far as including the folder into my browser and got the message in the console.
`[7TV] [INFO] Injected into twitch (content)`
But nothing more happend and I never got any emotes or additional buttons

If you are interested in functional components and hooks, I can start looking at some more complicated components, this is a small example how they look.

The big benefits are
- usually shorter and simpler to read 
- the power of hooks (also read https://reactjs.org/docs/hooks-overview.html)