### PR TITLE
Removed hardcoded chat width in theatre mode

### DIFF
--- a/src/Style/Components/YouTube/TheaterMode.scss
+++ b/src/Style/Components/YouTube/TheaterMode.scss
@@ -49,7 +49,6 @@
 
 		[id="secondary"] {
 			padding: 0 !important;
-			width: 340px !important;
 		}
 	}
 


### PR DESCRIPTION
Whenever i was using theatre mode on youtube the chat would be slightly narrower than normal. This might be due to using a 2k screen rather than a 1080p one. Removing the width made the chat appear the normal width again. Adding an ability to change chat width from the settings might be an idea in the future?
![svR7X8L](https://user-images.githubusercontent.com/49245223/134579911-f58fc07f-bfcc-432c-a331-8201ab850709.png)

![4rVocQq](https://user-images.githubusercontent.com/49245223/134579727-5615985c-132e-4578-a38b-a0f3b95752a7.png)
.