### PR TITLE
Double @ fix

### DIFF
--- a/src/Sites/twitch.tv/Runtime/ChatListener.ts
+++ b/src/Sites/twitch.tv/Runtime/ChatListener.ts
@@ -28,13 +28,12 @@ export class TwitchChatListener {
 		// Detect rerenders
 		const listener = this; // Get class context to pass it into the function
 		const x = this.twitch.getChatController().componentDidUpdate; // Get current componentDidUpdate()
-		const isFFZ = this.page.ffzMode;
 
 		if (!this.page.ffzMode) {
 			const controller = this.twitch.getChatController();
 			if (!!controller) {
 				controller.componentDidUpdate = function (a, b) {
-					if (isFFZ) {
+					if (listener.page.ffzMode) {
 						return;
 					}
 


### PR DESCRIPTION
Fixes the Double @ when having both 7tv and ffz installed. The historical view of messages and the first message would have a double @'User'. This would only happen in channels where you are a moderator. The reason was that the ffzMode variable was set at when the currentHandler.start() was first called. At this point the ffz hook hasn't loaded yet, so it would be set to false. Later when the first message is sendt and the componentDidUpdate() is called, the local ffzMode is still set to false, at which point it should be true. 