### PR TITLE
Fix youtube input box not updating after adding emote from menu

### DIFF
--- a/src/Sites/youtube.com/Util/YouTube.ts
+++ b/src/Sites/youtube.com/Util/YouTube.ts
@@ -34,6 +34,7 @@ export namespace YouTube {
 	export interface InputElement extends HTMLDivElement {
 		__data: InputData;
 		liveChatRichMessageInput: InputData['liveChatRichMessageInput'];
+		onInputChange_: () => void;
 	}
 
 	/** YouTube Message Data */

--- a/src/Sites/youtube.com/youtube.tsx
+++ b/src/Sites/youtube.com/youtube.tsx
@@ -47,14 +47,16 @@ export class YouTubePageScript {
 				}
 
 				input.__data.isInputValid = true;
-				input.liveChatRichMessageInput.textSegments.push({ text: emote.name });
+				input.liveChatRichMessageInput.textSegments.push({ text: emote.name + ' '});
 				const inputTextField = input.querySelector('#input');
 				if (!!inputTextField) {
-					inputTextField.textContent += emote.name + ' ';
+					// \xA0 is a non breaking space
+					inputTextField.textContent += emote.name + '\xA0';
 				}
 				if (!input.hasAttribute('has-text')) {
 					input.setAttribute('has-text', '');
 				}
+				input.onInputChange_();
 			})
 		).subscribe();
 	}


### PR DESCRIPTION
This fixes youtube's chat input box not updating after adding an emote.
Users no longer have to add a space after adding an emote for the chat input box to update.