### PR TITLE
Fix youtube popout wrong channel id

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,4 +6,4 @@
 - Twitch: Emote events should now reflect in chat immediately again
 - YouTube: Fixed an issue where clicking an emote in the menu did not allow sending the message
 - YouTube: Hyperlinks should now be clickable again
-- YouTube: Fixed an issue where channel emotes were showing as the current user in popout mode
+- YouTube: Fixed an issue where channel emotes were showing as the current user in popout mode (#177)

--- a/changelog.md
+++ b/changelog.md
@@ -6,3 +6,4 @@
 - Twitch: Emote events should now reflect in chat immediately again
 - YouTube: Fixed an issue where clicking an emote in the menu did not allow sending the message
 - YouTube: Hyperlinks should now be clickable again
+- YouTube: Fixed an issue where channel emotes were showing as the current user in popout mode

--- a/src/Sites/youtube.com/youtube.tsx
+++ b/src/Sites/youtube.com/youtube.tsx
@@ -176,7 +176,6 @@ export class YouTubePageScript {
 				.sendLiveChatMessageEndpoint
 				.params;
 
-			//Copied from bttv
 			channelID = atob(decodeURIComponent(atob(channelID)))
 			.split(`*'\n\u0018`)[1]
 			.split('\u0012\u000b')[0];

--- a/src/Sites/youtube.com/youtube.tsx
+++ b/src/Sites/youtube.com/youtube.tsx
@@ -163,22 +163,27 @@ export class YouTubePageScript {
 	 */
 	private scrapeChannelID(): string {
 		const inputRenderer = (document.getElementsByTagName('yt-live-chat-renderer')[0] as HTMLElement & { __data: any; });
-		let user: YouTubePageScript.InternalUserData | null = null;
+		let channelID = '';
 		try {
-			user = inputRenderer.__data.data
+			channelID = inputRenderer
+				.__data
+				.data
 				.actionPanel
 				.liveChatMessageInputRenderer
 				.sendButton
 				.buttonRenderer
 				.serviceEndpoint
 				.sendLiveChatMessageEndpoint
-				.actions[0]
-				.addLiveChatTextMessageFromTemplateAction
-				.template
-				.liveChatTextMessageRenderer;
+				.params;
+
+			//Copied from bttv
+			channelID = atob(decodeURIComponent(atob(channelID)))
+			.split(`*'\n\u0018`)[1]
+			.split('\u0012\u000b')[0];
+
 		} catch (_) {}
 
-		return user?.authorExternalChannelId ?? '';
+		return channelID ?? '';
 	}
 
 	/**


### PR DESCRIPTION
Fixed an issue where the current users channel id was used for channel emotes instead of the channel's.