### PR TITLE
Fix Bad Imports

### DIFF
--- a/src/Global/Util.ts
+++ b/src/Global/Util.ts
@@ -1,7 +1,7 @@
 import { DataStructure } from '@typings/typings/DataStructure';
 import { Config } from 'src/Config';
 import Color from 'color';
-import { createTheme } from '@material-ui/core';
+import createTheme from '@material-ui/core/styles/createTheme';
 
 export function getRunningContext(): Context {
 	try {

--- a/src/Sites/app/Settings/SettingsForm.tsx
+++ b/src/Sites/app/Settings/SettingsForm.tsx
@@ -5,10 +5,12 @@ import Input from '@material-ui/core/OutlinedInput';
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import FormGroup from '@material-ui/core/FormGroup';
+import FormLabel from '@material-ui/core/FormLabel';
+import RadioGroup from '@material-ui/core/RadioGroup';
+import Radio from '@material-ui/core/Radio';
 import { SettingNode } from 'src/Content/Runtime/Settings';
 import { MainComponent } from 'src/Sites/app/MainComponent';
 import { SettingValue } from 'src/Global/Util';
-import { SelectChangeEvent, RadioGroup, Radio, FormLabel } from '@material-ui/core';
 
 export class SettingsForm extends React.Component<SettingsForm.Props> {
 	render() {
@@ -67,7 +69,7 @@ export class SettingsForm extends React.Component<SettingsForm.Props> {
 		this.props.main.setState({});
 	}
 
-	handleSelectChange(sNode: SettingNode, ev: SelectChangeEvent): void {
+	handleSelectChange(sNode: SettingNode, ev: any): void {
 		const value = ev.target.value;
 
 		sNode.value = value;

--- a/src/Sites/twitch.tv/Components/BanSlider.tsx
+++ b/src/Sites/twitch.tv/Components/BanSlider.tsx
@@ -1,6 +1,6 @@
 import React, { PointerEvent, useState } from 'react';
-import { Restore } from '@material-ui/icons';
-import { SvgIcon } from '@material-ui/core';
+import Restore from '@material-ui/icons/Restore';
+import SvgIcon from '@material-ui/core/SvgIcon';
 
 const minVal = 40.0;
 const delVal = 80.0;


### PR DESCRIPTION
Fixing bad imports of `material-ui`, which were importing the entire package in several instances, causing the output bundle size to swell into ridiculous sizes.

@Excellify 🤨 