### PR TITLE
Fixed handling of long urls in YouTube chat

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # 7TV Web Extension - Changelog
 
+### Version 2.0.3
+
+- YouTube: Fixed an issue where long links would not work correctly (#181)
+
 ### Version 2.0.2
 
 - Twitch: Added a Moderation Slider tool (#170)
@@ -7,7 +11,3 @@
 - YouTube: Fixed an issue where clicking an emote in the menu did not allow sending the message
 - YouTube: Hyperlinks should now be clickable again
 - YouTube: Fixed an issue where channel emotes were showing as the current user in popout mode (#177)
-
-### Version 2.0.3
-
-- YouTube: Fixed an issue where long links would not work correctly (#181)

--- a/changelog.md
+++ b/changelog.md
@@ -7,3 +7,7 @@
 - YouTube: Fixed an issue where clicking an emote in the menu did not allow sending the message
 - YouTube: Hyperlinks should now be clickable again
 - YouTube: Fixed an issue where channel emotes were showing as the current user in popout mode (#177)
+
+### Version 2.0.3
+
+- YouTube: Fixed an issue where long links would not work correctly (#181)

--- a/src/Sites/youtube.com/Runtime/Tokenizer.ts
+++ b/src/Sites/youtube.com/Runtime/Tokenizer.ts
@@ -49,8 +49,8 @@ export class Tokenizer {
 					if (!this.addEmotePart(newContext, s)){
 						this.addTextPart(newContext, ' ');
 						s === me
-							?this.addMentionPart(newContext, s)
-							:this.addTextPart(newContext, s + ' ');
+							? this.addMentionPart(newContext, s)
+							: this.addTextPart(newContext, s + ' ');
 					}
 				}
 			}

--- a/src/Sites/youtube.com/Runtime/Tokenizer.ts
+++ b/src/Sites/youtube.com/Runtime/Tokenizer.ts
@@ -35,22 +35,22 @@ export class Tokenizer {
 		const newContext = document.createElement('span');
 		newContext.classList.add('seventv-yt-message-content');
 		const me = this.element.querySelector('.mention')?.textContent ?? null;
-		const isMod = this.element.__data.authorBadges.some(x => ['MODERATOR', 'OWNER'].includes(x.liveChatAuthorBadgeRenderer?.icon?.iconType));
 
 		for (let i = 0; i < this.element.__data.data.message.runs.length; i++) {
 			const part = this.element.__data.data.message.runs[i];
 
 			if (!!part.emoji) {
 				this.addEmojiPart(newContext, part.emoji);
+			} else if (!!part.navigationEndpoint && !!part.text) {
+				this.addTextPart(newContext, ' ');
+				this.addHyperlinkPart(newContext, part.text, part.navigationEndpoint);
 			} else if (!!part.text) {
 				for (let s of part.text.split(' ')) {
 					if (!this.addEmotePart(newContext, s)){
-						if (!isMod || !this.addHyperlinkPart(newContext, s)){
-							this.addTextPart(newContext, ' ');
-							s === me
-								?this.addMentionPart(newContext, s)
-								:this.addTextPart(newContext, s + ' ');
-						}
+						this.addTextPart(newContext, ' ');
+						s === me
+							?this.addMentionPart(newContext, s)
+							:this.addTextPart(newContext, s + ' ');
 					}
 				}
 			}
@@ -75,18 +75,13 @@ export class Tokenizer {
 	/**
 	 * Append a text part to the new message context
 	 */
-	addHyperlinkPart(ctx: HTMLSpanElement, text: string): boolean {
+	addHyperlinkPart(ctx: HTMLSpanElement, text: string, data: YouTube.NavigationEndpoint): void {
 		const a = document.createElement('a');
 		a.innerText = text;
 		a.className = 'yt-simple-endpoint style-scope yt-live-chat-text-message-renderer';
-		a.href = text;
+		a.href = data.urlEndpoint.url;
 		a.target = '_blank';
-
-		if (a.host && a.host != window.location.host) {
-			ctx.appendChild(a);
-			return true;
-		}
-		return false;
+		ctx.appendChild(a);
 	}
 
 	/**

--- a/src/Sites/youtube.com/Util/YouTube.ts
+++ b/src/Sites/youtube.com/Util/YouTube.ts
@@ -73,6 +73,7 @@ export namespace YouTube {
 				runs: {
 					text?: string;
 					emoji?: Emoji;
+					navigationEndpoint?: NavigationEndpoint
 				}[];
 			};
 			timestampUsec: string;
@@ -102,6 +103,12 @@ export namespace YouTube {
 		isCustomEmoji: boolean;
 		searchTerms?: string[];
 		shortcuts?: string[];
+	}
+
+	export interface NavigationEndpoint {
+		urlEndpoint: {
+			url: string;
+		};
 	}
 
 	export interface AppToken {


### PR DESCRIPTION
Fixed an issue with longer urls that were converted into https://example.com/something/asd... redirecting to the ... insead of the underlying full url.
Also removed the check for mod as the messages dont go through in the first place if the user isnt of the correct userlevel.