### PR TITLE
fixed position of youtube cooldown timer

### DIFF
--- a/src/Style/Style.scss
+++ b/src/Style/Style.scss
@@ -80,6 +80,11 @@ div[id="content"]
 	height: 1.95em !important;
 }
 
+// Move the YouTube Slowmode countdown back over the Send button
+.yt-live-chat-message-input-renderer#countdown {
+	left: -73px;
+}
+
 .seventv-message-context > :first-child {
 	margin-right: 0.25em;
 }


### PR DESCRIPTION
yt adds a hidden countdown svg to the message-buttons elements and lazily sets a left value to align it with the send button. this fix adjusts that value to be in line with it once again after the 7tv emote button is rendered.

closes
#153 
#188 