### PR TITLE
Fix paints on firefox

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # 7TV Web Extension - Changelog
 
+### Version 2.1.1
+
+- Fixed paints on firefox
+
 ### Version 2.1.0
 
 - Added new cosmetic feature: Paints

--- a/src/Sites/app/SiteApp.tsx
+++ b/src/Sites/app/SiteApp.tsx
@@ -135,14 +135,14 @@ export class SiteApp {
 
 	getAppStylesheet(): CSSStyleSheet | null {
 		const stylesheetURL = assetStore.get('stylesheet');
-		
+
 		// Firefox fix - Create new stylesheet
 		if (stylesheetURL?.startsWith('moz')) {
 			const style = document.createElement('style');
 			style.title = '7TV Paints';
 			style.appendChild(document.createTextNode(''));
 			document.head.appendChild(style);
-			
+
 			return style.sheet;
 		}
 

--- a/src/Sites/app/SiteApp.tsx
+++ b/src/Sites/app/SiteApp.tsx
@@ -138,11 +138,11 @@ export class SiteApp {
 		
 		// Firefox fix - Create new stylesheet
 		if (stylesheetURL?.startsWith('moz')) {
-			var style = document.createElement("style");
-			style.title = '7TV Paints'
-			style.appendChild(document.createTextNode(""));
+			const style = document.createElement('style');
+			style.title = '7TV Paints';
+			style.appendChild(document.createTextNode(''));
 			document.head.appendChild(style);
-
+			
 			return style.sheet;
 		}
 

--- a/src/Sites/app/SiteApp.tsx
+++ b/src/Sites/app/SiteApp.tsx
@@ -135,6 +135,17 @@ export class SiteApp {
 
 	getAppStylesheet(): CSSStyleSheet | null {
 		const stylesheetURL = assetStore.get('stylesheet');
+		
+		// Firefox fix - Create new stylesheet
+		if (stylesheetURL?.startsWith('moz')) {
+			var style = document.createElement("style");
+			style.title = '7TV Paints'
+			style.appendChild(document.createTextNode(""));
+			document.head.appendChild(style);
+
+			return style.sheet;
+		}
+
 		let stylesheet: CSSStyleSheet | null = null;
 
 		// Find our stylesheet


### PR DESCRIPTION
Fixes paints on firefox. 
Firefox dosnt allow you to access stylesheets that come from a different source than the origin. This includes all extensions as well as our own stylesheet for some reason.
Creates and returns a new stylesheet if the user is using firefox. 