### PR TITLE
Open emote card on click

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # 7TV Web Extension - Changelog
 
+### Version 2.1.2
+
+- Clicking a twitch emote now opens the emote card.
+
 ### Version 2.1.1
 
 - Paints with transparency can now blend in with the original chat user color

--- a/src/Sites/twitch.tv/Components/MessageTree.tsx
+++ b/src/Sites/twitch.tv/Components/MessageTree.tsx
@@ -26,6 +26,22 @@ export class MessageTree {
 	getWords(): string[] {
 		return this.msg.seventv.words;
 	}
+	getOnClick(emote: Twitch.ChatMessage.EmoteRef): (e: Event) => void {
+		return (e: Event): void => {
+			const opener = (new Twitch).getEmoteCardOpener();
+			const rect = (e.target as HTMLElement).getBoundingClientRect();
+
+			// channelID and channelLogin can be included here.
+			// Although i don't know if it changes anything.
+			opener.onShowEmoteCard({
+				emoteID: emote.emoteID,
+				emoteCode: emote.alt,
+				sourceID: 'chat',
+				initialTopOffset: rect.bottom,
+				initialBottomOffset: rect.top
+			});
+		};
+	}
 
 	/**
 	 * Fill the message tree with content defined by the tokenizer
@@ -113,6 +129,8 @@ export class MessageTree {
 		const data = part.content as Twitch.ChatMessage.EmoteRef;
 		const emote = this.previousEmote = emoteStore.fromTwitchEmote(data);
 		const emoteElement = emote.toElement();
+
+		emoteElement.onclick = this.getOnClick(data);
 
 		// For cheer emotes, display the amount
 		if (typeof data.cheerAmount === 'number' && data.cheerAmount > 0) {

--- a/src/Sites/twitch.tv/Components/MessageTree.tsx
+++ b/src/Sites/twitch.tv/Components/MessageTree.tsx
@@ -129,7 +129,7 @@ export class MessageTree {
 		const data = part.content as Twitch.ChatMessage.EmoteRef;
 		const emote = this.previousEmote = emoteStore.fromTwitchEmote(data);
 		const emoteElement = emote.toElement();
-
+		emoteElement.classList.add('twitch-emote');
 		emoteElement.onclick = this.getOnClick(data);
 
 		// For cheer emotes, display the amount

--- a/src/Sites/twitch.tv/Util/Twitch.ts
+++ b/src/Sites/twitch.tv/Util/Twitch.ts
@@ -138,6 +138,17 @@ export class Twitch {
 
 		return lines as Twitch.ChatLineAndComponent[];
 	}
+
+	getEmoteCardOpener(): Twitch.EmoteCardOpener {
+		const inst = document.querySelector(Twitch.Selectors.ChatContainer);
+
+		// This has to walk deep FeelsDankMan
+		const opener = this.findReactParents(
+			this.getReactInstance(inst),
+			n => n.stateNode.onShowEmoteCard, 200 );
+
+		return opener?.stateNode;
+	}
 }
 
 export namespace Twitch {
@@ -349,6 +360,10 @@ export namespace Twitch {
 		onValueUpdate: (v: any) => void;
 	}>;
 
+	export interface EmoteCardOpener {
+		onShowEmoteCard: (v: any) => void;
+	}
+
 	export interface TwitchEmoteSet {
 		id: string;
 		emotes: TwitchEmote[];
@@ -434,6 +449,7 @@ export namespace Twitch {
 		ffz_emotes: any;
 		emotes?: any;
 		_ffz_checked?: boolean;
+		opener?: Twitch.EmoteCardOpener;
 
 	}
 	export namespace ChatMessage {

--- a/src/Style/Style.scss
+++ b/src/Style/Style.scss
@@ -96,6 +96,10 @@ div[id="content"]
 	margin-right: 0.25em;
 }
 
+.twitch-emote {
+	cursor: pointer;
+}
+
 .seventv-mention {
 	font-weight: bold;
 }


### PR DESCRIPTION
Reinstates the ability to open the emote card by clicking twitch emotes. 

Closes: #18 
Closes: #184 