### PR TITLE
Fix paints style builder

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ### Version 2.1.2
 
 - Clicking a twitch emote now opens the emote card.
+- Fixed an issue with some paint styles.
 
 ### Version 2.1.1
 

--- a/src/Sites/app/SiteApp.tsx
+++ b/src/Sites/app/SiteApp.tsx
@@ -211,7 +211,7 @@ export class SiteApp {
 			// Insert new css rule for the paint
 			stylesheet.insertRule(`
 				body:not(.seventv-no-paints) [data-seventv-paint="${i}"] {
-					${paint.color === null ? '' : `color: ${decimalColorToRGBA(paint.color)}`}
+					${paint.color === null ? '' : `color: ${decimalColorToRGBA(paint.color)};`}
 					filter: ${dropShadow ? `drop-shadow(${dropShadow.join(' ')})` : 'inherit'};
 					background-clip: text !important;
 					background-size: cover !important;


### PR DESCRIPTION
Fixes a missing semicolon in the paints style builder that caused the color and drop shadow to not work when a color was included in the paint. 