### PR TITLE
Remove breaking change introduced by #193

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 
 ### Version 2.1.3
 
-- Twitch: Fixed some errors with the colon-complete (#201)
+- Twitch: Fixed an issue preventing the extension from loading properly (#193)
+- Twitch: Fixed some errors with colon-completion (#201)
 
 ### Version 2.1.2
 

--- a/src/Sites/twitch.tv/twitch.tsx
+++ b/src/Sites/twitch.tv/twitch.tsx
@@ -34,17 +34,7 @@ export class TwitchPageScript {
 		return twitch;
 	}
 
-	/**
-	 * The PageScript is the lower layer of the extension, it nests itself directly into the page
-	 * in order to gain access to Twitch's react instance and components.
-	 *
-	 * The purpose of PageScript is primarily to relay info and events back to the content script,
-	 * no rendering should be done at this layer as it may conflict with Twitch itself, and can easily
-	 * cause major memory leak problems.
-	 */
 	constructor() {
-		if (!window.location.href.match(this.channelRegex)) return;
-
 		this.handleChannelSwitch();
 		this.avatarManager.check();
 


### PR DESCRIPTION
Removing a change that was introduced by #193, which currently breaks the extension when the user starts with a twitch page other than a channel page