### PR TITLE
Display category headers above settings

### DIFF
--- a/src/Sites/app/Settings/SettingsForm.tsx
+++ b/src/Sites/app/Settings/SettingsForm.tsx
@@ -14,46 +14,84 @@ import { SettingValue } from 'src/Global/Util';
 
 export class SettingsForm extends React.Component<SettingsForm.Props> {
 	render() {
+
+		// this code could be pushed back to parent, but it might also be worth refactoring the entire SettingNode datatype
+		// to a better hierarchy ({category: setting[]}?)
+		// will settle with this in the mean time.
+		let categories : { [category: string] : SettingNode[] } = {};
+		for(let setting of this.props.settings) {
+			// syntax id: <category>.setting
+			let categoryTerminator = setting.id.indexOf(".");
+
+			// default to general category if syntax miss
+			let catName = categoryTerminator >= 0 ? setting.id.substring(0, categoryTerminator) : "general";
+
+			
+			(categories[catName] = categories[catName] || []).push(setting);
+		}
+
+		let categoryNames = Object.keys(categories);
+
+		// Sort categories by names
+		categoryNames.sort( (a,b) => {
+			// Put general first always
+			if(a == "general") {
+				return -1;
+			} else {
+				// Otherwise sort alphabetically
+				return a.localeCompare(b);
+			}
+		})
+
 		return (
 			<FormGroup>
-				{this.props.settings.map(s => {
-					const isDisabled = typeof s.disabledIf === 'function' ? s.disabledIf() : false;
-					let result: JSX.Element;
-					switch (s.type) {
-						case 'checkbox':
-							result =
-								<FormControlLabel label={s.label} sx={{ '.MuiFormControlLabel-label': { fontSize: '1em', color: 'currentcolor' }, '.MuiButtonBase-root': { color: 'currentcolor' } }} control={
-									<Checkbox
-										checked={(this.props.main.app?.config.get(s.id)?.asBoolean() ?? s.defaultValue) as boolean}
-										onChange={ev => this.handleCheckboxChange(s, ev)}
-										sx={{ '& .MuiSvgIcon-root': { fontSize: 24, marginLeft: '14px' } }} />
-								}></FormControlLabel>;
-							break;
+				{categoryNames.map(categoryName => {
+					let categorySettings : JSX.Element[] = [];
+		
+					categorySettings.push(<h1 id={"cat-" + categoryName + "-title"} style={{fontSize: '1.2em', marginLeft: "14px"}}>{categoryName.toUpperCase()}</h1>);
+					
+					for(let setting of categories[categoryName]) {
+						const isDisabled = typeof setting.disabledIf === 'function' ? setting.disabledIf() : false;
+						let result: JSX.Element;
+						switch (setting.type) {
+							case 'checkbox':
+								result =
+									<FormControlLabel label={setting.label} sx={{ '.MuiFormControlLabel-label': { fontSize: '1em', color: 'currentcolor' }, '.MuiButtonBase-root': { color: 'currentcolor' } }} control={
+										<Checkbox
+											checked={(this.props.main.app?.config.get(setting.id)?.asBoolean() ?? setting.defaultValue) as boolean}
+											onChange={ev => this.handleCheckboxChange(setting, ev)}
+											sx={{ '& .MuiSvgIcon-root': { fontSize: 24, marginLeft: '14px' } }} />
+									}></FormControlLabel>;
+								break;
 
 
-						case 'select':
-							result =
-								<div>
-									<FormLabel component='legend' style={{ fontSize: '1em', color: 'currentcolor', margin: '14px 0 0 14px'}}>{s.label}</FormLabel>
-									<RadioGroup style={{ marginLeft: '14px'}} name='Test' sx={{ '.MuiFormControlLabel-label': { fontSize: '1em', color: 'currentcolor' }, '.MuiButtonBase-root': { color: 'currentcolor' } }} onChange={ev => this.handleSelectChange(s, ev)} value={(this.props.main.app?.config.get(s.id)?.asString() ?? s.defaultValue) as string}>
-											{s.options?.map((option) => <FormControlLabel style={{textTransform:'capitalize'}} value={option} key={option} control={<Radio />} label={option} /> )}
-									</RadioGroup>
-								</div>;
-							break;
+							case 'select':
+								result =
+									<div>
+										<FormLabel component='legend' style={{ fontSize: '1em', color: 'currentcolor', margin: '14px 0 0 14px'}}>{setting.label}</FormLabel>
+										<RadioGroup style={{ marginLeft: '14px'}} name='Test' sx={{ '.MuiFormControlLabel-label': { fontSize: '1em', color: 'currentcolor' }, '.MuiButtonBase-root': { color: 'currentcolor' } }} onChange={ev => this.handleSelectChange(setting, ev)} value={(this.props.main.app?.config.get(setting.id)?.asString() ?? setting.defaultValue) as string}>
+												{setting.options?.map((option) => <FormControlLabel style={{textTransform:'capitalize'}} value={option} key={option} control={<Radio />} label={option} /> )}
+										</RadioGroup>
+									</div>;
+								break;
 
-						default:
-							result =
-								<Input placeholder='Generic Input'></Input>;
-							break;
+							default:
+								result =
+									<Input placeholder='Generic Input'></Input>;
+								break;
+						}
+
+						categorySettings.push(<FormControl disabled={isDisabled} component='fieldset' sx={{
+							'.Mui-disabled': { color: 'red' }
+						}} key={`formcontrol-${setting.id}`} id={setting.id}>
+							{result}
+							<FormHelperText style={{ fontSize: '0.75em', color: 'currentcolor', opacity: '0.60' }}> {setting.hint} </FormHelperText>
+						</FormControl>);
 					}
-
-					return <FormControl disabled={isDisabled} component='fieldset' sx={{
-						'.Mui-disabled': { color: 'red' }
-					}} key={`formcontrol-${s.id}`} id={s.id}>
-						{result}
-						<FormHelperText style={{ fontSize: '0.75em', color: 'currentcolor', opacity: '0.60' }}> {s.hint} </FormHelperText>
-					</FormControl>;
+					//									 46px = 3* 14px from form margin
+					return (<div style={{marginBottom: "46px", display: "flex", flexDirection: "column"}}>{categorySettings}</div>);
 				})}
+				
 			</FormGroup>
 		);
 	}


### PR DESCRIPTION
This adds a simple header and some margin to seperate the categories of settings.
![preview](https://user-images.githubusercontent.com/29798218/150447312-2e21663c-3e46-47ba-b61b-991539f1ecb6.png)

This also opens the possibility to use the implemented, but unused, tabs feature. where clicking on a category-tag simply scrolls to the corresponding category. will try to add this soon
