### PR TITLE
Fixed emoji width being altered on YT

### DIFF
--- a/src/Style/Style.scss
+++ b/src/Style/Style.scss
@@ -74,6 +74,7 @@ div[id="content"]
 
 .emoji {
 	height: 1.95em !important;
+	width: auto !important;
 }
 
 // Move the YouTube Slowmode countdown back over the Send button


### PR DESCRIPTION
Emoji width on youtube was sometimes altered by higher priority CSS which used exact pixels of 16 and made the emojis look messed up and thin

#215 