### PR TITLE
Updated position CSS of the overlay class.

### DIFF
--- a/src/Style/Style.scss
+++ b/src/Style/Style.scss
@@ -44,6 +44,10 @@ div[id="content"]
 .seventv-overlay {
 	display: flex;
 	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
 	background-color: transparent;
 	color: var(--seventv-text-color);
 


### PR DESCRIPTION
Fix for #147 

The parent element of the overlay element differ between https://dashboard.twitch.tv/ and https://www.twitch.tv/. This resulted in the positioning behaviour of the overlay differing on the 2 sites. This change should make sure the position of the overlay is consistent on the 2 sites.