### PR TITLE
Updated ban slider styling to support suspicious user messages.

### DIFF
--- a/src/Sites/twitch.tv/Components/BanSliderManager.tsx
+++ b/src/Sites/twitch.tv/Components/BanSliderManager.tsx
@@ -84,6 +84,7 @@ export class BanSliderManager {
 
 					const container = document.createElement('span');
 					container.classList.add('seventv-ban-slider');
+					line.element.style.position = 'relative';
 					line.element.insertBefore(container, line.element.firstChild);
 					const old_mount = line.component.componentWillUnmount;
 

--- a/src/Style/Components/BanSlider.scss
+++ b/src/Style/Components/BanSlider.scss
@@ -56,6 +56,7 @@
         top: 0;
         pointer-events: none;
         user-select: none;
+        z-index: 1;
     
         .outer {
             height: 100%;


### PR DESCRIPTION
Fix for #221 

The chat line for a suspicious message has position static, and the ban slider is laid out assuming the chat line has position relative. This change will make all chat lines with a ban slider position relative. If you think this is unsafe, I can restrict this change to apply only for suspicious message chat lines. Alternatively, I can modify the ban slider to work with a position static chat line.