### PR TITLE
Added support for VOD and Clips on Twitch.

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -21,13 +21,13 @@ jobs:
 
       - name: Lint
         run: |
-          npm install
-          npm run lint
+          yarn
+          yarn lint
 
       - name: Build
         run: |
-          npm run build-prod-chromium
-          npm run build-prod-firefox
+          yarn build-prod-chromium
+          yarn build-prod-firefox
 
       - name: ZIP Releases
         run: |

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # 7TV Web Extension - Changelog
 
+### Version 2.2.0
+
+- Added support for chat in VODs
+
 ### Version 2.1.4
 
 - Twitch: Fixed tab-completion for Twitch's chat input update

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ### Version 2.2.0
 
-- Added support for chat in VODs
+- Added support for chat in VODs (#234)
 
 ### Version 2.1.4
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/react-lazyload": "^3.1.0",
     "@types/styled-components": "^5.1.7",
     "@types/superagent": "^4.1.10",
-    "@types/twemoji": "^12.1.1",
+    "@types/twemoji": "^13.1.2",
     "babel-loader": "^8.2.2",
     "color": "^3.1.3",
     "eslint": "^7.20.0",
@@ -68,6 +68,6 @@
     "rxjs": "^6.6.3",
     "styled-components": "^5.2.1",
     "superagent": "^6.1.0",
-    "twemoji": "^13.0.2"
+    "twemoji": "^14.0.2"
   }
 }

--- a/src/Sites/twitch.tv/Components/MessageRenderer.tsx
+++ b/src/Sites/twitch.tv/Components/MessageRenderer.tsx
@@ -64,7 +64,11 @@ export class MessageRenderer {
 
 		if (typeof authorID === 'string') {
 			(() => {
-				const usernameContainer = container.querySelector(Twitch.Selectors.ChatUsernameContainer); // Chat Line - Username Container
+				const usernameContainer =
+					live
+					? container.querySelector(Twitch.Selectors.ChatUsernameContainer) // Chat Line - Username Container
+					: container?.parentElement; // Chat line container for VODs
+
 				const badgeList = this.app.badgeMap.get(parseInt(authorID)); // Get the badge index ID for this user
 				if (!Array.isArray(badgeList) || badgeList.length === 0) {
 					return undefined;

--- a/src/Sites/twitch.tv/Components/MessageRenderer.tsx
+++ b/src/Sites/twitch.tv/Components/MessageRenderer.tsx
@@ -45,17 +45,15 @@ export class MessageRenderer {
 		}
 		// Render emojis
 		newContext.querySelectorAll('span').forEach(span => {
-			if (twemoji.test(span.innerText)) {
-				twemoji.parse(span, {
-					className: 'seventv-emoji'
-				});
-				const emojis = span.querySelectorAll('img');
-				for (const emoji of Array.from(emojis)) {
-					const emoteji = this.app.emoteStore.fromEmoji(emoji);
-					emoji.title = emoteji.name;
-					emoji.width = 19.5;
-					emoji.height = 19.5;
-				}
+			twemoji.parse(span, {
+				className: 'seventv-emoji',
+			});
+			const emojis = span.querySelectorAll<HTMLImageElement>('img.seventv-emoji');
+			for (const emoji of Array.from(emojis)) {
+				const emoteji = this.app.emoteStore.fromEmoji(emoji);
+				emoji.title = emoteji.name;
+				emoji.width = 19.5;
+				emoji.height = 19.5;
 			}
 		});
 

--- a/src/Sites/twitch.tv/Components/MessageRenderer.tsx
+++ b/src/Sites/twitch.tv/Components/MessageRenderer.tsx
@@ -9,7 +9,7 @@ export class MessageRenderer {
 
 	constructor(
 		public app: SiteApp,
-		public msg: Twitch.ChatMessage,
+		public msg: Twitch.ChatMessage | Twitch.VideoChatComment,
 		public elementId: string
 	) {
 		this.element = document.getElementById(elementId);
@@ -55,7 +55,7 @@ export class MessageRenderer {
 		});
 
 		// Render user badges
-		const authorID = this.msg.user?.userID;
+		const authorID = (this.msg as Twitch.ChatMessage).user?.userID ?? (this.msg as Twitch.VideoChatComment)?.commenter;
 		if (typeof authorID === 'string') {
 			(() => {
 				const usernameContainer = container.querySelector(Twitch.Selectors.ChatUsernameContainer); // Chat Line - Username Container

--- a/src/Sites/twitch.tv/Components/MessageRenderer.tsx
+++ b/src/Sites/twitch.tv/Components/MessageRenderer.tsx
@@ -29,7 +29,7 @@ export class MessageRenderer {
 			c.remove();
 		});
 
-		const container = el.querySelector('.chat-line__no-background') ?? el.querySelector(Twitch.Selectors.ChatMessageContainer) ?? el;
+		const container = el.querySelector('.chat-line__no-background, .video-chat__message') ?? el.querySelector(Twitch.Selectors.ChatMessageContainer) ?? el;
 		const newContext = document.createElement('span');
 		newContext.classList.add('seventv-message-context');
 		newContext.style.position = 'relative';

--- a/src/Sites/twitch.tv/Components/MessageRenderer.tsx
+++ b/src/Sites/twitch.tv/Components/MessageRenderer.tsx
@@ -19,7 +19,7 @@ export class MessageRenderer {
 		return document.querySelector(Twitch.Selectors.ChatScrollableContainer);
 	}
 
-	insert(): void {
+	insert(live?: boolean): void {
 		const el = this.element;
 		if (!el) return undefined;
 
@@ -29,7 +29,12 @@ export class MessageRenderer {
 			c.remove();
 		});
 
-		const container = el.querySelector('.chat-line__no-background, .video-chat__message') ?? el.querySelector(Twitch.Selectors.ChatMessageContainer) ?? el;
+		const container = el.querySelector(
+			live
+			? '.chat-line__no-background'
+			: '.video-chat__message'
+		) ?? el.querySelector(Twitch.Selectors.ChatMessageContainer) ?? el;
+
 		const newContext = document.createElement('span');
 		newContext.classList.add('seventv-message-context');
 		newContext.style.position = 'relative';
@@ -55,7 +60,10 @@ export class MessageRenderer {
 		});
 
 		// Render user badges
-		const authorID = (this.msg as Twitch.ChatMessage).user?.userID ?? (this.msg as Twitch.VideoChatComment)?.commenter;
+		const authorID = live
+			? (this.msg as Twitch.ChatMessage).user?.userID
+			: (this.msg as Twitch.VideoChatComment)?.commenter;
+
 		if (typeof authorID === 'string') {
 			(() => {
 				const usernameContainer = container.querySelector(Twitch.Selectors.ChatUsernameContainer); // Chat Line - Username Container

--- a/src/Sites/twitch.tv/Components/MessageTree.tsx
+++ b/src/Sites/twitch.tv/Components/MessageTree.tsx
@@ -11,12 +11,15 @@ export class MessageTree {
 
 	}
 
-	get msg(): Twitch.ChatMessage {
+	get msg(): Twitch.ChatMessage | Twitch.VideoChatComment {
 		return this.renderer.msg;
 	}
 
 	getMessageColor(): string {
-		return this.msg.seventv.is_slash_me ? this.msg.user.color : '';
+		return this.msg.seventv.is_slash_me
+			? (this.msg as Twitch.ChatMessage)?.user.color
+				?? (this.msg as Twitch.VideoChatComment)?.message.userColor
+			: '';
 	}
 
 	getParts(): Part[] {
@@ -97,7 +100,7 @@ export class MessageTree {
 		if (part.content === ' ') {
 			span.classList.add('seventv-text-empty');
 		}
-		const color = this.msg.seventv.is_slash_me ? this.msg.user.color : '';
+		const color = this.getMessageColor();
 		if (part.content?.toLowerCase().includes(this.msg.seventv?.currentUserLogin)) {
 			this.renderer.element?.classList.add('seventv-message-mentioned');
 		}

--- a/src/Sites/twitch.tv/Components/MessageTree.tsx
+++ b/src/Sites/twitch.tv/Components/MessageTree.tsx
@@ -132,8 +132,12 @@ export class MessageTree {
 		const data = part.content as Twitch.ChatMessage.EmoteRef;
 		const emote = this.previousEmote = emoteStore.fromTwitchEmote(data);
 		const emoteElement = emote.toElement();
-		emoteElement.classList.add('twitch-emote');
-		emoteElement.onclick = this.getOnClick(data);
+
+		// Note: Only live chats have emote cards.
+		if (document.querySelector(Twitch.Selectors.ChatContainer)) {
+			emoteElement.classList.add('twitch-emote');
+			emoteElement.onclick = this.getOnClick(data);
+		}
 
 		// For cheer emotes, display the amount
 		if (typeof data.cheerAmount === 'number' && data.cheerAmount > 0) {

--- a/src/Sites/twitch.tv/Runtime/BaseChatListener.ts
+++ b/src/Sites/twitch.tv/Runtime/BaseChatListener.ts
@@ -1,9 +1,5 @@
-import { Constants } from '@typings/src/Constants';
-import { DataStructure } from '@typings/typings/DataStructure';
 import { Subject } from 'rxjs';
-import { emoteStore } from 'src/Sites/app/SiteApp';
 import { TwitchPageScript } from 'src/Sites/twitch.tv/twitch';
-import { Twitch } from 'src/Sites/twitch.tv/Util/Twitch';
 
 
 export abstract class BaseTwitchChatListener {
@@ -18,36 +14,6 @@ export abstract class BaseTwitchChatListener {
 
 	abstract start(): void;
 	abstract listen(): void;
-
-	insertTwitchGlobalEmotesToSet(emoteSets: Twitch.TwitchEmoteSet[]): void {
-		// Iterate through sets, and start adding to our twitch set
-		const emotes = [] as DataStructure.Emote[];
-		for (const twset of emoteSets) {
-			for (const emote of twset.emotes) {
-				emotes.push({
-					id: emote.id,
-					name: emote.token,
-					visibility: 0,
-					provider: 'TWITCH',
-					status: Constants.Emotes.Status.LIVE,
-					tags: [],
-					width: [28, 56, 112, 112],
-					height: [28, 56, 112, 112],
-					owner: !!twset.owner ? {
-						id: twset.owner.id,
-						display_name: twset.owner.displayName,
-						login: twset.owner.login
-					} as DataStructure.TwitchUser : undefined
-				});
-			}
-		}
-
-		// Delete the twitch set if it already existed then recreate it
-		if (emoteStore.sets.has('twitch')) {
-			emoteStore.sets.delete('twitch');
-		}
-		emoteStore.enableSet(`twitch`, emotes);
-	}
 
 	kill(): void {
 		this.killed.next(undefined);

--- a/src/Sites/twitch.tv/Runtime/BaseChatListener.ts
+++ b/src/Sites/twitch.tv/Runtime/BaseChatListener.ts
@@ -1,5 +1,7 @@
 import { Subject } from 'rxjs';
 import { TwitchPageScript } from 'src/Sites/twitch.tv/twitch';
+import { MessagePatcher } from 'src/Sites/twitch.tv/Util/MessagePatcher';
+import { Twitch } from 'src/Sites/twitch.tv/Util/Twitch';
 
 
 export abstract class BaseTwitchChatListener {
@@ -15,6 +17,65 @@ export abstract class BaseTwitchChatListener {
 	abstract start(): void;
 	abstract listen(): void;
 	abstract sendSystemMessage(message: string): void;
+
+	/**
+	 * Renders the user's display name with a custom 7TV paint effect if they have one.
+	 * Otherwise, use render their name with their assigned Twitch color.
+	 */
+	renderPaintOnNametag(
+		user: { id: string },
+		messageElement: Element,
+		originalColor: string,
+		userNameQuery: string
+	) {
+		const userID = parseInt(user.id);
+
+		// Add custom paint.
+		const paintMap = this.page.site.paintMap;
+		if (user && paintMap.has(userID)) {
+			const paintID = paintMap.get(userID);
+
+			if (typeof paintID !== 'number') {
+				return undefined;
+			}
+
+			const paint = this.page.site.paints[paintID];
+			const username = messageElement.querySelector<HTMLAnchorElement>(userNameQuery);
+			username?.setAttribute('data-seventv-paint', paintID.toString());
+
+			// No paint color? Use Twitch assigned color.
+			if (!paint.color && originalColor && username) {
+				username.style.color = originalColor;
+			}
+		}
+	}
+
+	/**
+	 * Prepares the message patcher with all the items SevenTV will replace/rerender
+	 * in the message. Searches for any recognized emotes and records them for rendering later.
+	 */
+	prepareMessageRender(
+		message: Twitch.ChatMessage | Twitch.VideoChatComment,
+		additionalConfigs: {},
+		live?: boolean
+	): MessagePatcher {
+		// Push emotes to seventv.emotes property
+		const patcher = new MessagePatcher(this.page, message);
+		message.seventv = {
+			patcher,
+			parts: [],
+			badges: [],
+			words: [],
+			live: live,
+			...additionalConfigs
+		};
+
+		// Tokenize 7TV emotes to Message Data
+		// This detects/matches 7TV emotes as text and adds it to a seventv namespace within the message
+		patcher.tokenize();
+
+		return patcher;
+	}
 
 	kill(): void {
 		this.killed.next(undefined);

--- a/src/Sites/twitch.tv/Runtime/BaseChatListener.ts
+++ b/src/Sites/twitch.tv/Runtime/BaseChatListener.ts
@@ -1,0 +1,22 @@
+import { Subject } from 'rxjs';
+import { TwitchPageScript } from 'src/Sites/twitch.tv/twitch';
+
+
+export abstract class BaseTwitchChatListener {
+	/** Create a Twitch instance bound to this listener */
+	protected twitch = this.page.twitch;
+
+	protected killed = new Subject<void>();
+
+	constructor(protected page: TwitchPageScript) {
+		(window as any).twitch = this.twitch;
+	}
+
+	abstract start(): void;
+	abstract listen(): void;
+
+	kill(): void {
+		this.killed.next(undefined);
+		this.killed.complete();
+	}
+}

--- a/src/Sites/twitch.tv/Runtime/BaseChatListener.ts
+++ b/src/Sites/twitch.tv/Runtime/BaseChatListener.ts
@@ -14,6 +14,7 @@ export abstract class BaseTwitchChatListener {
 
 	abstract start(): void;
 	abstract listen(): void;
+	abstract sendSystemMessage(message: string): void;
 
 	kill(): void {
 		this.killed.next(undefined);

--- a/src/Sites/twitch.tv/Runtime/BaseChatListener.ts
+++ b/src/Sites/twitch.tv/Runtime/BaseChatListener.ts
@@ -1,5 +1,9 @@
+import { Constants } from '@typings/src/Constants';
+import { DataStructure } from '@typings/typings/DataStructure';
 import { Subject } from 'rxjs';
+import { emoteStore } from 'src/Sites/app/SiteApp';
 import { TwitchPageScript } from 'src/Sites/twitch.tv/twitch';
+import { Twitch } from 'src/Sites/twitch.tv/Util/Twitch';
 
 
 export abstract class BaseTwitchChatListener {
@@ -14,6 +18,36 @@ export abstract class BaseTwitchChatListener {
 
 	abstract start(): void;
 	abstract listen(): void;
+
+	insertTwitchGlobalEmotesToSet(emoteSets: Twitch.TwitchEmoteSet[]): void {
+		// Iterate through sets, and start adding to our twitch set
+		const emotes = [] as DataStructure.Emote[];
+		for (const twset of emoteSets) {
+			for (const emote of twset.emotes) {
+				emotes.push({
+					id: emote.id,
+					name: emote.token,
+					visibility: 0,
+					provider: 'TWITCH',
+					status: Constants.Emotes.Status.LIVE,
+					tags: [],
+					width: [28, 56, 112, 112],
+					height: [28, 56, 112, 112],
+					owner: !!twset.owner ? {
+						id: twset.owner.id,
+						display_name: twset.owner.displayName,
+						login: twset.owner.login
+					} as DataStructure.TwitchUser : undefined
+				});
+			}
+		}
+
+		// Delete the twitch set if it already existed then recreate it
+		if (emoteStore.sets.has('twitch')) {
+			emoteStore.sets.delete('twitch');
+		}
+		emoteStore.enableSet(`twitch`, emotes);
+	}
 
 	kill(): void {
 		this.killed.next(undefined);

--- a/src/Sites/twitch.tv/Runtime/ChatListener.ts
+++ b/src/Sites/twitch.tv/Runtime/ChatListener.ts
@@ -1,9 +1,6 @@
-import { Constants } from '@typings/src/Constants';
-import { DataStructure } from '@typings/typings/DataStructure';
 import { Observable } from 'rxjs';
 import { filter, takeUntil, tap } from 'rxjs/operators';
 import { Logger } from 'src/Logger';
-import { emoteStore } from 'src/Sites/app/SiteApp';
 import { TwitchPageScript } from 'src/Sites/twitch.tv/twitch';
 import { MessagePatcher } from 'src/Sites/twitch.tv/Util/MessagePatcher';
 import { Twitch } from 'src/Sites/twitch.tv/Util/Twitch';
@@ -231,35 +228,5 @@ export class TwitchChatListener extends BaseTwitchChatListener {
 				childList: true
 			});
 		});
-	}
-
-	insertTwitchGlobalEmotesToSet(emoteSets: Twitch.TwitchEmoteSet[]): void {
-		// Iterate through sets, and start adding to our twitch set
-		const emotes = [] as DataStructure.Emote[];
-		for (const twset of emoteSets) {
-			for (const emote of twset.emotes) {
-				emotes.push({
-					id: emote.id,
-					name: emote.token,
-					visibility: 0,
-					provider: 'TWITCH',
-					status: Constants.Emotes.Status.LIVE,
-					tags: [],
-					width: [28, 56, 112, 112],
-					height: [28, 56, 112, 112],
-					owner: !!twset.owner ? {
-						id: twset.owner.id,
-						display_name: twset.owner.displayName,
-						login: twset.owner.login
-					} as DataStructure.TwitchUser : undefined
-				});
-			}
-		}
-
-		// Delete the twitch set if it already existed then recreate it
-		if (emoteStore.sets.has('twitch')) {
-			emoteStore.sets.delete('twitch');
-		}
-		emoteStore.enableSet(`twitch`, emotes);
 	}
 }

--- a/src/Sites/twitch.tv/Runtime/ChatListener.ts
+++ b/src/Sites/twitch.tv/Runtime/ChatListener.ts
@@ -1,6 +1,9 @@
+import { Constants } from '@typings/src/Constants';
+import { DataStructure } from '@typings/typings/DataStructure';
 import { Observable } from 'rxjs';
 import { filter, takeUntil, tap } from 'rxjs/operators';
 import { Logger } from 'src/Logger';
+import { emoteStore } from 'src/Sites/app/SiteApp';
 import { TwitchPageScript } from 'src/Sites/twitch.tv/twitch';
 import { MessagePatcher } from 'src/Sites/twitch.tv/Util/MessagePatcher';
 import { Twitch } from 'src/Sites/twitch.tv/Util/Twitch';
@@ -228,5 +231,35 @@ export class TwitchChatListener extends BaseTwitchChatListener {
 				childList: true
 			});
 		});
+	}
+
+	insertTwitchGlobalEmotesToSet(emoteSets: Twitch.TwitchEmoteSet[]): void {
+		// Iterate through sets, and start adding to our twitch set
+		const emotes = [] as DataStructure.Emote[];
+		for (const twset of emoteSets) {
+			for (const emote of twset.emotes) {
+				emotes.push({
+					id: emote.id,
+					name: emote.token,
+					visibility: 0,
+					provider: 'TWITCH',
+					status: Constants.Emotes.Status.LIVE,
+					tags: [],
+					width: [28, 56, 112, 112],
+					height: [28, 56, 112, 112],
+					owner: !!twset.owner ? {
+						id: twset.owner.id,
+						display_name: twset.owner.displayName,
+						login: twset.owner.login
+					} as DataStructure.TwitchUser : undefined
+				});
+			}
+		}
+
+		// Delete the twitch set if it already existed then recreate it
+		if (emoteStore.sets.has('twitch')) {
+			emoteStore.sets.delete('twitch');
+		}
+		emoteStore.enableSet(`twitch`, emotes);
 	}
 }

--- a/src/Sites/twitch.tv/Runtime/ChatListener.ts
+++ b/src/Sites/twitch.tv/Runtime/ChatListener.ts
@@ -5,7 +5,6 @@ import { filter, takeUntil, tap } from 'rxjs/operators';
 import { Logger } from 'src/Logger';
 import { emoteStore } from 'src/Sites/app/SiteApp';
 import { TwitchPageScript } from 'src/Sites/twitch.tv/twitch';
-import { MessagePatcher } from 'src/Sites/twitch.tv/Util/MessagePatcher';
 import { Twitch } from 'src/Sites/twitch.tv/Util/Twitch';
 import { intervalToDuration, formatDuration } from 'date-fns';
 import { BaseTwitchChatListener } from 'src/Sites/twitch.tv/Runtime/BaseChatListener';
@@ -109,7 +108,7 @@ export class TwitchChatListener extends BaseTwitchChatListener {
 			filter(line => !!line.component),
 			// Render 7TV emotes
 			tap(line => {
-				this.renderPaintOnNametag(line);
+				this.renderNametagPaint(line);
 
 				if (!!line.component.props.message?.seventv) {
 					line.component.props.message.seventv.currenUserID = line.component.props.currentUserID;
@@ -127,33 +126,26 @@ export class TwitchChatListener extends BaseTwitchChatListener {
 		for (const line of lines) {
 			if (!line.component?.props) continue;
 			this.onMessage(line.component.props.message, line);
-			this.renderPaintOnNametag(line);
+			this.renderNametagPaint(line);
 		}
 	}
 
 	/**
 	 * Patch a chat line with a nametag paint when applicable
 	 */
-	renderPaintOnNametag(line: Twitch.ChatLineAndComponent): void {
+	renderNametagPaint(line: Twitch.ChatLineAndComponent): void {
 		if (!line.component.props || !line.component.props.message) {
 			return undefined;
 		}
-		const user = line.component.props.message.user;
-		const userID = parseInt(user.userID);
-		// Add paint?
-		if (!!user && this.page.site.paintMap.has(userID)) {
-			const paintID = this.page.site.paintMap.get(userID);
-			if (typeof paintID !== 'number') {
-				return undefined;
-			}
-			const paint = this.page.site.paints[paintID];
-			const username = line.element.querySelector<HTMLSpanElement>('[data-a-target="chat-message-username"], .chat-line__username');
-			username?.setAttribute('data-seventv-paint', paintID.toString());
 
-			if (!paint.color && username) {
-				username.style.color = line.component.props.message.user.color;
-			}
-		}
+		const user = line.component.props.message.user;
+
+		super.renderPaintOnNametag(
+			{ id: user.userID },
+			line.element,
+			user.color,
+			'[data-a-target="chat-message-username"], .chat-line__username'
+		);
 	}
 
 	private onMessage(msg: Twitch.ChatMessage, renderAs: Twitch.ChatLineAndComponent | null = null): void {
@@ -164,19 +156,11 @@ export class TwitchChatListener extends BaseTwitchChatListener {
 		 */
 		this.pendingMessages.add(msg.id);
 
-		// Push emotes to seventv.emotes property
-		const patcher = new MessagePatcher(this.page, msg);
-		msg.seventv = {
-			patcher,
-			parts: [],
-			badges: [],
-			words: [],
-			is_slash_me: msg.messageType === 1
-		};
-
-		// Tokenize 7TV emotes to Message Data
-		// This detects/matches 7TV emotes as text and adds it to a seventv namespace within the message
-		patcher.tokenize();
+		const patcher = super.prepareMessageRender(
+			msg,
+			{ is_slash_me: msg.messageType === 1 },
+			true
+		);
 
 		this.linesRendered++;
 		if (this.linesRendered === 1) {

--- a/src/Sites/twitch.tv/Runtime/ChatListener.ts
+++ b/src/Sites/twitch.tv/Runtime/ChatListener.ts
@@ -1,6 +1,6 @@
 import { Constants } from '@typings/src/Constants';
 import { DataStructure } from '@typings/typings/DataStructure';
-import { Observable, Subject } from 'rxjs';
+import { Observable } from 'rxjs';
 import { filter, takeUntil, tap } from 'rxjs/operators';
 import { Logger } from 'src/Logger';
 import { emoteStore } from 'src/Sites/app/SiteApp';
@@ -8,21 +8,18 @@ import { TwitchPageScript } from 'src/Sites/twitch.tv/twitch';
 import { MessagePatcher } from 'src/Sites/twitch.tv/Util/MessagePatcher';
 import { Twitch } from 'src/Sites/twitch.tv/Util/Twitch';
 import { intervalToDuration, formatDuration } from 'date-fns';
+import { BaseTwitchChatListener } from 'src/Sites/twitch.tv/Runtime/BaseChatListener';
 
 let currentHandler: (msg: Twitch.ChatMessage) => void;
-export class TwitchChatListener {
-	/** Create a Twitch instance bound to this listener */
-	private twitch = this.page.twitch;
+export class TwitchChatListener extends BaseTwitchChatListener {
 
 	/** A list of message IDs which have been received but not yet rendered on screen */
 	private pendingMessages = new Set<string>();
 
 	linesRendered = 0;
 
-	private killed = new Subject<void>();
-
-	constructor(private page: TwitchPageScript) {
-		(window as any).twitch = this.twitch;
+	constructor(page: TwitchPageScript) {
+		super(page);
 	}
 
 	start(): void {
@@ -264,10 +261,5 @@ export class TwitchChatListener {
 			emoteStore.sets.delete('twitch');
 		}
 		emoteStore.enableSet(`twitch`, emotes);
-	}
-
-	kill(): void {
-		this.killed.next(undefined);
-		this.killed.complete();
 	}
 }

--- a/src/Sites/twitch.tv/Runtime/InputManager.tsx
+++ b/src/Sites/twitch.tv/Runtime/InputManager.tsx
@@ -87,7 +87,7 @@ export class InputManager {
 				} else { // Notify the user they could enable the setting to send duplicate messages
 					if (this.lastMessage === target.value && !this.noticedAboutAllowSendTwice) {
 						this.noticedAboutAllowSendTwice = true;
-						this.page.chatListener.sendSystemMessage('Enable the setting "Allow sending the same message twice" in the 7TV settings menu to bypass the duplicate message restriction');
+						this.page.chatListener?.sendSystemMessage('Enable the setting "Allow sending the same message twice" in the 7TV settings menu to bypass the duplicate message restriction');
 					}
 					this.lastMessage = value;
 				}

--- a/src/Sites/twitch.tv/Runtime/VideoChatListener.ts
+++ b/src/Sites/twitch.tv/Runtime/VideoChatListener.ts
@@ -25,11 +25,17 @@ export class TwitchVideoChatListener extends BaseTwitchChatListener {
     }
 
     listen(): void {
+
+        // Let FFZ handle things if it's available.
+        if (this.page.ffzMode) {
+            return;
+        }
+        
         Logger.Get().info('Listen for chat messages');
 
         this.observeDOM().pipe(
             takeUntil(this.killed),
-            filter(message => !!message.component),  // TODO: Account for resub messages that have no component state.
+            filter(message => !!message.component),  // Ignore messages with no component states, like subs/resubs.
             tap(message => {
                 this.renderPaintOnNametag(message);
                 this.onMessage(message);

--- a/src/Sites/twitch.tv/Runtime/VideoChatListener.ts
+++ b/src/Sites/twitch.tv/Runtime/VideoChatListener.ts
@@ -1,0 +1,72 @@
+import { Logger } from 'src/Logger';
+import { BaseTwitchChatListener } from 'src/Sites/twitch.tv/Runtime/BaseChatListener';
+import { TwitchPageScript } from 'src/Sites/twitch.tv/twitch';
+import { Twitch } from 'src/Sites/twitch.tv/Util/Twitch';
+
+
+let currentHandler: (comment: Twitch.VideoChatComment) => void;
+
+export class TwitchVideoChatListener extends BaseTwitchChatListener {
+
+    constructor(page: TwitchPageScript) {
+        super(page);
+    }
+
+    start(): void {
+        const listener = this;
+
+        // Handle changes only if FFZ isn't enabled.
+        if (!this.page.ffzMode) {
+
+            Logger.Get().debug('Twitch video chat rerender detected, rendering 7TV emotes');
+            setTimeout(() => listener.renderAll(listener.twitch.getVideoMessages()), 1000);
+        }
+    }
+
+    listen(): void {
+
+    }
+
+    private renderAll(messages: Twitch.VideoMessageAndComponent[]): void {
+        for (const message of messages) {
+            if (!message.component?.props) {
+                continue;
+            }
+
+            this.renderPaintOnNametag(message);
+        }
+    }
+
+    renderPaintOnNametag(message: Twitch.VideoMessageAndComponent) {
+
+        const props = message.component.props;
+        if (!props || !props.context) {
+            return undefined;
+        }
+
+        const user = props.context.author;
+        const userID = parseInt(user.id);
+
+        console.log(props.context.comment.message.userColor)
+
+        // Add custom paint.
+        const paintMap = this.page.site.paintMap;
+        if (user && paintMap.has(userID)) {
+            const paintID = paintMap.get(userID);
+
+            if (typeof paintID !== 'number') {
+                return undefined;
+            }
+
+            const paint = this.page.site.paints[paintID];
+            const username = message.element.querySelector<HTMLAnchorElement>('.video-chat__message-author');
+            username?.setAttribute('data-seventv-paint', paintID.toString());
+
+            // No paint color? Use Twitch assigned color.
+            const userColor = props.context.comment.message.userColor;
+            if (!paint.color && userColor && username) {
+                username.style.color = userColor;
+            }
+        }
+    }
+}

--- a/src/Sites/twitch.tv/Util/MessagePatcher.tsx
+++ b/src/Sites/twitch.tv/Util/MessagePatcher.tsx
@@ -5,7 +5,7 @@ import { Twitch } from 'src/Sites/twitch.tv/Util/Twitch';
 export class MessagePatcher {
 	constructor(
 		private page: TwitchPageScript,
-		private msg: Twitch.ChatMessage
+		private msg: Twitch.ChatMessage | Twitch.VideoChatComment
 	) { }
 
 	/**
@@ -16,8 +16,11 @@ export class MessagePatcher {
 		// Daily Quest: find 7TV emotes ZULUL
 		const eIndex = this.page.getEmoteIndex();
 
+		const messageParts = (this.msg as Twitch.ChatMessage)?.messageParts
+			?? (this.msg as Twitch.VideoChatComment)?.message.tokens;
+
 		// Find all emotes across the message parts
-		for (const part of this.msg.messageParts) {
+		for (const part of messageParts) {
 			// Handle link / mention
 			if (part.type === 4) { // Is mention
 				this.msg.seventv.parts.push({ type: 'mention', content: (part.content as any).recipient });

--- a/src/Sites/twitch.tv/Util/MessagePatcher.tsx
+++ b/src/Sites/twitch.tv/Util/MessagePatcher.tsx
@@ -85,15 +85,8 @@ export class MessagePatcher {
 	 */
 	render(line: Twitch.ChatLineAndComponent | Twitch.VideoMessageAndComponent): void {
 		// Hide twitch fragments
-		// Note: Some VOD fragments, like Twitch emotes, contain an additional layout that also needs to be hidden. Hence: div[class^=InjectLayout-sc-]
-		// All user badges also have layouts, so they need to be excluded from removal.
-		const oldFragments = Array.from(line.element.querySelectorAll<HTMLSpanElement | HTMLImageElement>('span.text-fragment, span.mention-fragment, a.link-fragment, img.chat-line__message--emote, [data-test-selector=emote-button], div[class^=InjectLayout-sc-]'));
+		const oldFragments = Array.from(line.element.querySelectorAll<HTMLSpanElement | HTMLImageElement>('span.text-fragment, span.mention-fragment, a.link-fragment, img.chat-line__message--emote, div.chat-image__container, [data-test-selector=emote-button]'));
 		for (const oldFrag of oldFragments) {
-
-			// Excludge layouts for badges from removal.
-			if (oldFrag.querySelectorAll(':scope > button[data-a-target=chat-badge]').length) {
-				continue;
-			}
 
 			oldFrag.setAttribute('superceded', '');
 			oldFrag.style.setProperty('display', 'none', 'important');	// VOD fragments with additional layout contain 'display: inline !important'. This needs to be overrode.

--- a/src/Sites/twitch.tv/Util/MessagePatcher.tsx
+++ b/src/Sites/twitch.tv/Util/MessagePatcher.tsx
@@ -85,8 +85,15 @@ export class MessagePatcher {
 	render(line: Twitch.ChatLineAndComponent | Twitch.VideoMessageAndComponent): void {
 		// Hide twitch fragments
 		// Note: Some VOD fragments, like Twitch emotes, contain an additional layout that also needs to be hidden. Hence: div[class^=InjectLayout-sc-]
+		// All user badges also have layouts, so they need to be excluded from removal.
 		const oldFragments = Array.from(line.element.querySelectorAll<HTMLSpanElement | HTMLImageElement>('span.text-fragment, span.mention-fragment, a.link-fragment, img.chat-line__message--emote, [data-test-selector=emote-button], div[class^=InjectLayout-sc-]'));
 		for (const oldFrag of oldFragments) {
+
+			// Excludge layouts for badges from removal.
+			if (oldFrag.querySelectorAll(':scope > button[data-a-target=chat-badge]').length) {
+				continue;
+			}
+
 			oldFrag.setAttribute('superceded', '');
 			oldFrag.style.setProperty('display', 'none', 'important');	// VOD fragments with additional layout contain 'display: inline !important'. This needs to be overrode.
 		}

--- a/src/Sites/twitch.tv/Util/MessagePatcher.tsx
+++ b/src/Sites/twitch.tv/Util/MessagePatcher.tsx
@@ -84,10 +84,11 @@ export class MessagePatcher {
 	 */
 	render(line: Twitch.ChatLineAndComponent | Twitch.VideoMessageAndComponent): void {
 		// Hide twitch fragments
-		const oldFragments = Array.from(line.element.querySelectorAll<HTMLSpanElement | HTMLImageElement>('span.text-fragment, span.mention-fragment, a.link-fragment, img.chat-line__message--emote, [data-test-selector=emote-button]'));
+		// Note: Some VOD fragments, like Twitch emotes, contain an additional layout that also needs to be hidden. Hence: div[class^=InjectLayout-sc-]
+		const oldFragments = Array.from(line.element.querySelectorAll<HTMLSpanElement | HTMLImageElement>('span.text-fragment, span.mention-fragment, a.link-fragment, img.chat-line__message--emote, [data-test-selector=emote-button], div[class^=InjectLayout-sc-]'));
 		for (const oldFrag of oldFragments) {
 			oldFrag.setAttribute('superceded', '');
-			oldFrag.style.display = 'none';
+			oldFrag.style.setProperty('display', 'none', 'important');	// VOD fragments with additional layout contain 'display: inline !important'. This needs to be overrode.
 		}
 
 		const message = (this.msg as Twitch.ChatMessage)

--- a/src/Sites/twitch.tv/Util/MessagePatcher.tsx
+++ b/src/Sites/twitch.tv/Util/MessagePatcher.tsx
@@ -16,8 +16,9 @@ export class MessagePatcher {
 		// Daily Quest: find 7TV emotes ZULUL
 		const eIndex = this.page.getEmoteIndex();
 
-		const messageParts = (this.msg as Twitch.ChatMessage)?.messageParts
-			?? (this.msg as Twitch.VideoChatComment)?.message.tokens;
+		const messageParts = this.msg.seventv.live
+			? (this.msg as Twitch.ChatMessage)?.messageParts
+			: (this.msg as Twitch.VideoChatComment)?.message.tokens;
 
 		// Find all emotes across the message parts
 		for (const part of messageParts) {
@@ -110,7 +111,7 @@ export class MessagePatcher {
 		const renderer = new MessageRenderer(this.page.site, message, line.element.id);
 
 		renderer.renderMessageTree();
-		renderer.insert();
+		renderer.insert(this.msg.seventv.live);
 	}
 
 	/**

--- a/src/Sites/twitch.tv/Util/MessagePatcher.tsx
+++ b/src/Sites/twitch.tv/Util/MessagePatcher.tsx
@@ -82,7 +82,7 @@ export class MessagePatcher {
 	/**
 	 * Render the message with 7TV emotes
 	 */
-	render(line: Twitch.ChatLineAndComponent): void {
+	render(line: Twitch.ChatLineAndComponent | Twitch.VideoMessageAndComponent): void {
 		// Hide twitch fragments
 		const oldFragments = Array.from(line.element.querySelectorAll<HTMLSpanElement | HTMLImageElement>('span.text-fragment, span.mention-fragment, a.link-fragment, img.chat-line__message--emote, [data-test-selector=emote-button]'));
 		for (const oldFrag of oldFragments) {
@@ -90,13 +90,16 @@ export class MessagePatcher {
 			oldFrag.style.display = 'none';
 		}
 
+		const message = (this.msg as Twitch.ChatMessage)
+			?? (this.msg as Twitch.VideoChatComment);
+
 		// Render 7TV third party stuff (and idk...)
 		// Send message data back to the content script
-		line.element.id = `7TV#msg:${this.msg.id}`; // Give an ID to the message element
-		line.element.setAttribute('seventv-id', this.msg.id);
+		line.element.id = `7TV#msg:${message.id}`; // Give an ID to the message element
+		line.element.setAttribute('seventv-id', message.id);
 		this.msg.seventv.patcher = null;
 
-		const renderer = new MessageRenderer(this.page.site, this.msg, line.element.id);
+		const renderer = new MessageRenderer(this.page.site, message, line.element.id);
 
 		renderer.renderMessageTree();
 		renderer.insert();

--- a/src/Sites/twitch.tv/Util/Twitch.ts
+++ b/src/Sites/twitch.tv/Util/Twitch.ts
@@ -40,9 +40,9 @@ export class Twitch {
 
 	getRouter(): Twitch.RouterComponent {
 		const node = this.findReactChildren(
-			this.getReactInstance(document.querySelectorAll(Twitch.Selectors.ROOT)[0]),
-			n => n.stateNode?.props?.match?.isExact === true,
-			1000
+			this.getReactInstance(document.querySelectorAll(Twitch.Selectors.MainLayout)[0]),
+			n => n.stateNode?.props?.history?.listen,
+			100
 		);
 
 		return node?.stateNode;
@@ -221,6 +221,7 @@ export namespace Twitch {
 	export namespace Selectors {
 		export const ROOT = '#root div';
 		export const NAV = '[data-a-target="top-nav-container"]';
+		export const MainLayout = 'main.twilight-main';
 		export const ChatContainer = 'section[data-test-selector="chat-room-component-layout"]';
 		export const VideoChatContainer = 'div.video-chat.va-vod-chat';
 		export const ChatScrollableContainer = '.chat-scrollable-area__message-container';
@@ -319,12 +320,28 @@ export namespace Twitch {
 	}>;
 
 	export type RouterComponent = React.PureComponent<{
-		isExact: boolean;
-		params: {
-			channel: string;
-		};
-		path: string;
-		url: string;
+
+		// React history object used for navigating.
+		history: {
+			action: string;
+			goBack: () => void;
+			goForward: () => void;
+			listen: (
+				handler: (
+					location: Location,
+					action: string
+				) => void
+			) => void;
+			location: Location;
+		}
+		location: Location;
+		isLoggedIn: boolean;
+		match: {
+			isExact: boolean;
+			params: { [key: string]: string }
+			path: string;
+			url: string;
+		}
 	}>;
 
 	export type ChatServiceComponent = React.PureComponent<{
@@ -504,6 +521,15 @@ export namespace Twitch {
 	export enum Theme {
 		'Light',
 		'Dark'
+	}
+
+	// Standard React location object.
+	export interface Location {
+		hash: string;
+		key: string;
+		pathname: string;
+		search: string;
+		state?: any;
 	}
 
 	export interface BitsConfig {

--- a/src/Sites/twitch.tv/Util/Twitch.ts
+++ b/src/Sites/twitch.tv/Util/Twitch.ts
@@ -184,7 +184,7 @@ export class Twitch {
 		return {
 			component: inst?.return?.return?.stateNode,
 			instance: inst as Twitch.TwitchPureComponent
-		}
+		};
 	}
 
 	/**
@@ -199,7 +199,7 @@ export class Twitch {
 					element,
 					component: message.component,
 					inst: message.instance
-				}
+				};
 			});
 
 		return messages as Twitch.VideoMessageAndComponent[];
@@ -542,8 +542,8 @@ export namespace Twitch {
 			tiers: { id: string; bits: number; canShowInBitsCard: boolean; __typename: string; };
 			template: string;
 			__typename: string;
-		}}
-	};
+		}};
+	}
 
 	export interface EmoteCardOpener {
 		onShowEmoteCard: (v: any) => void;

--- a/src/Sites/twitch.tv/Util/Twitch.ts
+++ b/src/Sites/twitch.tv/Util/Twitch.ts
@@ -606,6 +606,7 @@ export namespace Twitch {
 		is_slash_me?: boolean;
 		currenUserID?: string;
 		currentUserLogin?: string;
+		live?: boolean;
 	}
 
 	export interface VideoChatComment {

--- a/src/Sites/twitch.tv/Util/Twitch.ts
+++ b/src/Sites/twitch.tv/Util/Twitch.ts
@@ -182,7 +182,7 @@ export class Twitch {
 		const inst = this.getReactInstance(element);
 
 		return {
-			component: inst?.child?.stateNode,
+			component: inst?.return?.return?.stateNode,
 			instance: inst as Twitch.TwitchPureComponent
 		}
 	}
@@ -225,7 +225,7 @@ export namespace Twitch {
 		export const VideoChatContainer = 'div.video-chat.va-vod-chat';
 		export const ChatScrollableContainer = '.chat-scrollable-area__message-container';
 		export const ChatLine = '.chat-line__message';
-		export const VideoChatMessage = '.vod-message > div:not(.vod-message__header)';
+		export const VideoChatMessage = '.vod-message > div:not(.vod-message__header) > div';
 		export const ChatInput = '.chat-input__textarea';
 		export const ChatInputButtonsContainer = 'div[data-test-selector="chat-input-buttons-container"]';
 		export const ChatMessageContainer = '.chat-line__message-container';

--- a/src/Sites/twitch.tv/twitch.tsx
+++ b/src/Sites/twitch.tv/twitch.tsx
@@ -217,8 +217,14 @@ export class TwitchPageScript {
 		const emoteProvider = this.twitch.getAutocompleteHandler().providers[0];
 
 		// Wait 500ms if twitch has not inserted its emotes.
-		if (emoteProvider.props.emotes.length == 0) {
-			setTimeout(this.insertEmotesIntoAutocomplete, 500);
+		if (emoteProvider.props.emotes.length === 0) {
+
+			// Note: The scope of 'this' changes to the window instead
+			// of the page script when the function is called with setTimeout().
+			// Lambda/arrow functions preserve the previous scope when called.
+			// See https://stackoverflow.com/a/11714413
+			// Alternatively, could use an observable.
+			setTimeout(() => this.insertEmotesIntoAutocomplete(), 500);
 			return;
 		}
 

--- a/src/Sites/twitch.tv/twitch.tsx
+++ b/src/Sites/twitch.tv/twitch.tsx
@@ -95,7 +95,7 @@ export class TwitchPageScript {
 
 					// Load VOD and clip items.
 					else {
-
+						this.videoChatListener.listen();
 					}
 
 					this.site.sendMessageUp('EventAPI:AddChannel', login);

--- a/src/Sites/twitch.tv/twitch.tsx
+++ b/src/Sites/twitch.tv/twitch.tsx
@@ -163,7 +163,7 @@ export class TwitchPageScript {
 		// Load the appropriate chat listener depending on what kind of
 		// chat is available: live or VOD/clip.
 		(
-			!(channelInfo as Twitch.VideoChannelComponent)
+			(channelInfo as Twitch.ChatControllerComponent)?.props.chatConnectionAPI
 			? this.chatListener
 			: this.videoChatListener
 		).start();

--- a/src/Sites/twitch.tv/twitch.tsx
+++ b/src/Sites/twitch.tv/twitch.tsx
@@ -113,7 +113,6 @@ export class TwitchPageScript {
 		// Determine channel for VODs and clips
 		else if (match.groups?.['videoid']) {
 			channelInfo = this.twitch.getVideoChannel();
-			this.currentVideo = match.groups['videoid'];
 		}
 
 		channelName = channelInfo?.props.channelLogin; // Set current channel
@@ -162,9 +161,9 @@ export class TwitchPageScript {
 		}, 500);
 
 		// Load the appropriate chat listener depending on what kind of
-		// chat is available: live, VOD, or clip.
+		// chat is available: live or VOD/clip.
 		(
-			!this.currentVideo
+			!(channelInfo as Twitch.VideoChannelComponent)
 			? this.chatListener
 			: this.videoChatListener
 		).start();

--- a/src/Sites/twitch.tv/twitch.tsx
+++ b/src/Sites/twitch.tv/twitch.tsx
@@ -65,7 +65,7 @@ export class TwitchPageScript {
 
 		// Get chat service
 		let channelName, channelID;
-		
+
 		const switchHandler = async (
 			location: Twitch.Location,
 			_action: string
@@ -164,7 +164,7 @@ export class TwitchPageScript {
 
 						// Begin handling new messages.
 						this.chatListener.listen();
-					}
+					};
 
 					// Are we waiting for emotes to be loaded? Yes? Then hold off on listening for new chat lines.
 					if (channelSwitchHandler) {
@@ -177,7 +177,7 @@ export class TwitchPageScript {
 					}
 				}
 			}
-		}
+		};
 
 		// Track routing using the page's router.
 		const router = this.twitch.getRouter();
@@ -185,7 +185,7 @@ export class TwitchPageScript {
 
 		// Run handler once on first page load.
 		switchHandler.apply(this, [history.location, history.action]);
-		
+
 		// Begin listening for page change events.
 		router.props.history.listen(switchHandler);
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,10 +1513,12 @@
     "@types/cookiejar" "*"
     "@types/node" "*"
 
-"@types/twemoji@^12.1.1":
-  version "12.1.2"
-  resolved "https://registry.yarnpkg.com/@types/twemoji/-/twemoji-12.1.2.tgz#52578fd22665311e6a78d04f800275449d51c97e"
-  integrity sha512-3eMyKenMi0R1CeKzBYtk/Z2JIHsTMQrIrTah0q54o45pHTpWVNofU2oHx0jS8tqsDRhis2TbB6238WP9oh2l2w==
+"@types/twemoji@^13.1.2":
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/@types/twemoji/-/twemoji-13.1.2.tgz#5d06e4093479254b43abf84ec56ee5c623161f88"
+  integrity sha512-vPNsrN08aRI2Gmdo+Ds3zZXzUk6igp1Hg+JPCeHavpiUGfgth/tGiHLQxfSrKzPXeRC0zbLs8WaUZSYxRWPbNg==
+  dependencies:
+    twemoji "*"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -5956,19 +5958,19 @@ tsutils@^2.29.0:
   dependencies:
     tslib "^1.8.1"
 
-twemoji-parser@13.1.0:
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/twemoji-parser/-/twemoji-parser-13.1.0.tgz#65e7e449c59258791b22ac0b37077349127e3ea4"
-  integrity sha512-AQOzLJpYlpWMy8n+0ATyKKZzWlZBJN+G0C+5lhX7Ftc2PeEVdUU/7ns2Pn2vVje26AIZ/OHwFoUbdv6YYD/wGg==
+twemoji-parser@14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/twemoji-parser/-/twemoji-parser-14.0.0.tgz#13dabcb6d3a261d9efbf58a1666b182033bf2b62"
+  integrity sha512-9DUOTGLOWs0pFWnh1p6NF+C3CkQ96PWmEFwhOVmT3WbecRC+68AIqpsnJXygfkFcp4aXbOp8Dwbhh/HQgvoRxA==
 
-twemoji@^13.0.2:
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-13.1.0.tgz#65bb71e966dae56f0d42c30176f04cbdae109913"
-  integrity sha512-e3fZRl2S9UQQdBFLYXtTBT6o4vidJMnpWUAhJA+yLGR+kaUTZAt3PixC0cGvvxWSuq2MSz/o0rJraOXrWw/4Ew==
+twemoji@*, twemoji@^14.0.2:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-14.0.2.tgz#c53adb01dab22bf4870f648ca8cc347ce99ee37e"
+  integrity sha512-BzOoXIe1QVdmsUmZ54xbEH+8AgtOKUiG53zO5vVP2iUu6h5u9lN15NcuS6te4OY96qx0H7JK9vjjl9WQbkTRuA==
   dependencies:
     fs-extra "^8.0.1"
     jsonfile "^5.0.0"
-    twemoji-parser "13.1.0"
+    twemoji-parser "14.0.0"
     universalify "^0.1.2"
 
 type-check@^0.4.0, type-check@~0.4.0:


### PR DESCRIPTION
This pull request is for #23.

It adds 7TV support (emotes, painted names, etc.) for video chats (VODs, clips). Here's a summary of the changes:

Twitch videos, for whatever reason, use very different components, models, and layouts compared to live chats. In addition, the chat controller, which has references to chat and message APIs, is not available for video chats. A separate listener and additional types were introduced to address these differences.

I also had to change the Twitch script handle process to use the available React history object for detecting route/url changes. While setInterval() works fine-ish when there's only one listener being loaded, it causes a race condition (at least for me) where 7TV embeds and handlers are being unintentionally unloaded or overwritten when going from channel to video or vice versa.

I tried my best to adapt the MessagePatcher, MessageTree, and MessageRenderer to recognize and handle video messages. Some of it is kind of hacky because of some slight differences between live and video messages. But for the most part, once you drill down to the individual messages, they're pretty similar and stuff seems to work.

Sorry in advance. I know there are a lot of changes.

I have tested on both Firefox and Vivaldi (Chromium). But definitely let me know if something is broken or needs to be changed.