### PR TITLE
Fix the "Send same message twice" option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 
 ### Version 2.2.0
 
-- Added support for chat in VODs (#234)
+- Twitch: Added support for chat in VODs (#234)
+- Twitch: The "Send same message twice" option should now work again (#239)
 
 ### Version 2.1.4
 

--- a/src/Sites/twitch.tv/Runtime/InputManager.tsx
+++ b/src/Sites/twitch.tv/Runtime/InputManager.tsx
@@ -155,6 +155,7 @@ export class InputManager {
 	}
 
 	setInputValue(value: string): void {
+		value = value.replace(/�/g, ''); // omit weird character
 		const el = document.querySelector('.chat-input textarea') as HTMLInputElement;
 		if (el && typeof el.value != undefined) {
 			el.value = value;


### PR DESCRIPTION
This feature appears to now be broken for most users following Twitch's near-complete rollout of the Slate-based chat input. This is a simple fix to hook with the new input.