### PR TITLE
Improve spamming functionality

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,9 +3,10 @@
 ### Version 2.2.0
 
 - Twitch: Added support for chat in VODs (#234)
-- Twitch: The "Send same message twice" option should now work again (#239)
+- Twitch: The "Send same message twice" option should now work again (#239, #241)
 - Twitch: The "Show Timeouts & Bans" option will now disable itself while acting as a moderator
 - Twitch: Improved the time formatting for time-out and ban notices (#218)
+- Twitch: Added provider indicators in emote colon-completion and fixed its inconsistent functionality
 - Twitch: Fixed an issue which caused FFZ emotes to sometimes be broken images or unexpected random images (#240)
 - Twitch: Fixed an issue which occasionally prevented name tag paints from rendering
 - Twitch: Tentatively fixed an issue which caused random emojis to appear in chat

--- a/src/Sites/app/SiteApp.tsx
+++ b/src/Sites/app/SiteApp.tsx
@@ -22,6 +22,7 @@ export class SiteApp {
 	paints = [] as API.Paint[];
 	badgeMap = new Map<number, number[]>();
 	paintMap = new Map<number, number>();
+	paintStyleRules = new Set<number>();
 	currentChannel = '';
 	tabCompleteDetector = new TabCompleteDetection(this);
 	config = config;
@@ -179,6 +180,18 @@ export class SiteApp {
 		if (!stylesheet) {
 			return undefined;
 		}
+		// Clear previous rules
+		this.paintStyleRules.forEach((i) => {
+			const r = stylesheet.cssRules.item(i);
+			if (!r) {
+				return;
+			}
+			const isPaint = r?.cssText.includes('data-seventv-paint');
+			if (isPaint) {
+				stylesheet.deleteRule(i);
+			}
+		});
+		this.paintStyleRules.clear();
 
 		// Turn the paint data into css rule
 		for (let i = 0; i < this.paints.length; i++) {
@@ -218,7 +231,7 @@ export class SiteApp {
 			}
 
 			// Insert new css rule for the paint
-			stylesheet.insertRule(`
+			this.paintStyleRules.add(stylesheet.insertRule(`
 				body:not(.seventv-no-paints) [data-seventv-paint="${i}"] {
 					${paint.color !== null ? `color: ${decimalColorToRGBA(paint.color)} !important;` : ''}
 					filter: ${dropShadows.length > 0
@@ -227,7 +240,7 @@ export class SiteApp {
 					};
 					background-image: ${funcName}(${args.join(', ')});
 				}
-			`.replace(/(\r\n|\n|\r)/gm, ''), stylesheet.cssRules.length);
+			`.replace(/(\r\n|\n|\r)/gm, ''), stylesheet.cssRules.length));
 
 			Logger.Get().debug(`Loaded cosmetic paint: '${paint.name}' (index: ${i}, id: ${paint.id})`);
 		}

--- a/src/Sites/twitch.tv/Runtime/InputManager.tsx
+++ b/src/Sites/twitch.tv/Runtime/InputManager.tsx
@@ -17,7 +17,6 @@ export class InputManager {
 	};
 	history = [''] as string[];
 	historyPos = 0;
-	noticedAboutAllowSendTwice = false;
 
 	restart = new Subject<void>();
 

--- a/src/Sites/twitch.tv/Runtime/InputManager.tsx
+++ b/src/Sites/twitch.tv/Runtime/InputManager.tsx
@@ -105,6 +105,7 @@ export class InputManager {
 		let alt = false;
 		ws.send = function (s: string) {
 			if (isAllowSendTwice()) {
+				// Set alternate unicode tag suffix
 				if (!alt) {
 					s += ' ' + unicodeTag0;
 				}
@@ -160,10 +161,10 @@ export class InputManager {
 				controller.componentDidUpdate = initOnUpdate;
 				controller.props.onSendMessage = initialOnSend;
 				ws.send = ircSend;
-				if (!!dupeCheck) {
+				if (!!controller.props.sendMessageErrorChecks?.['duplicated-messages']) {
 					controller.props.sendMessageErrorChecks['duplicated-messages'].check = dupeCheck;
 				}
-				if (!!throughputCheck) {
+				if (!!controller.props.sendMessageErrorChecks?.['message-throughput']) {
 					controller.props.sendMessageErrorChecks['message-throughput'].check = throughputCheck;
 				}
 			}

--- a/src/Sites/twitch.tv/Runtime/InputManager.tsx
+++ b/src/Sites/twitch.tv/Runtime/InputManager.tsx
@@ -104,7 +104,7 @@ export class InputManager {
 		const ircSend = ws.send;
 		let alt = false;
 		ws.send = function (s: string) {
-			if (isAllowSendTwice()) {
+			if (!actorCanSpam && isAllowSendTwice()) {
 				// Set alternate unicode tag suffix
 				if (!alt) {
 					s += ' ' + unicodeTag0;

--- a/src/Sites/twitch.tv/Util/Twitch.ts
+++ b/src/Sites/twitch.tv/Util/Twitch.ts
@@ -121,8 +121,15 @@ export class Twitch {
 		return node?.stateNode;
 	}
 
-	getChatInput(): Twitch.ChatInputComponent {
+	getInputController(): Twitch.ChatInputController {
+		const node = this.findReactParents(
+			this.getReactInstance(document.querySelectorAll('div.chat-input')[0]),
+			n => n.stateNode?.props.onSendMessage,
+		);
+		return node?.stateNode;
+	}
 
+	getChatInput(): Twitch.ChatInputComponent {
 		return this.getAutocompleteHandler()?.componentRef;
 	}
 
@@ -456,6 +463,20 @@ export namespace Twitch {
 		onDeleteComment: (n: any) => void;
 		videoID: string;
 	}>;
+
+	export type ChatInputController = React.Component<{
+		sendMessageErrorChecks: Record<'duplicated-messages' | 'message-throughput', {
+			check: (value: string) => any;
+			onMessageSent: (x: any) => any;
+		}>;
+		chatConnectionAPI: {
+			sendMessage: Function;
+		};
+	}> & {
+		props: {
+			onSendMessage: (value: string) => any;
+		}
+	};
 
 	export type ChatInputComponent = React.Component<{
 		channelID: string;

--- a/src/Sites/twitch.tv/Util/Twitch.ts
+++ b/src/Sites/twitch.tv/Util/Twitch.ts
@@ -50,9 +50,9 @@ export class Twitch {
 
 	getChatService(): Twitch.ChatServiceComponent {
 		const node = this.findReactChildren(
-			this.getReactInstance(document.querySelectorAll(Twitch.Selectors.ROOT)[0]),
+			this.getReactInstance(document.querySelectorAll(Twitch.Selectors.MainLayout)[0]),
 			n => n.stateNode?.join && n.stateNode?.client,
-			1000
+			500
 		);
 
 		return node?.stateNode;


### PR DESCRIPTION
Code cleanup of the spamming features such as duplicate message bypass and ctrl+enter.

## Changed
- Now inserts the invisible character when sending a `PRIVMSG` through IRC rather than modifying the input box. 
- Ctrl+Enter now hooks into the chat controller and overwrites the message send function to keep the message in the box. Also implements its own cooldown to avoid getting rejections as a pleb

## Issues
- [x] Emotes break when the websocket reconnects