### PR TITLE
Fix for replying on twitch

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # 7TV Web Extension - Changelog
 
+### Version 2.2.1
+
+- Fixed an issue which broke the reply functionality on Twitch
+
 ### Version 2.2.0
 
 - Twitch: Added support for chat in VODs (#234)

--- a/src/Sites/twitch.tv/Runtime/InputManager.tsx
+++ b/src/Sites/twitch.tv/Runtime/InputManager.tsx
@@ -135,7 +135,7 @@ export class InputManager {
 		const initialOnSend = controller.props.onSendMessage;
 		const initOnUpdate = controller.componentDidUpdate;
 		controller.componentDidUpdate = function (p, st) {
-			controller.props.onSendMessage = function(s: string) {
+			controller.props.onSendMessage = function(s: string, reply) {
 				if (keepInput) {
 					if (!cooldown) {
 						// Set a cooldown
@@ -149,7 +149,7 @@ export class InputManager {
 					}
 					return;
 				}
-				return initialOnSend.apply(this, [s]);
+				return initialOnSend.apply(this, [s, reply]);
 			};
 			return initOnUpdate?.apply(this, [p, st]);
 		};

--- a/src/Sites/twitch.tv/Util/Twitch.ts
+++ b/src/Sites/twitch.tv/Util/Twitch.ts
@@ -474,7 +474,14 @@ export namespace Twitch {
 		};
 	}> & {
 		props: {
-			onSendMessage: (value: string) => any;
+			onSendMessage: (value: string, reply: {
+				parentDeleted: boolean;
+				parentDisplayName: string;
+				parentMessageBodsy: string;
+				parentMsgId: string;
+				parentUid: string;
+				parentUserLogin: string;
+			}) => any;
 		}
 	};
 


### PR DESCRIPTION
Fixing an issue which broke the reply feature on twitch. This was caused by a secondary parameter in the input controller's `onSendMessage` function being discarded by 7TV's IRC handler.

Fixes #243 