### PR TITLE
Fix video cutoff in true theater mode on youtube

### DIFF
--- a/src/Style/Components/YouTube/TheaterMode.scss
+++ b/src/Style/Components/YouTube/TheaterMode.scss
@@ -37,6 +37,7 @@
 						width: 100% !important;
 						height: 100% !important;
 						left: 0 !important;
+						object-fit: contain !important;
 					}
 
 					.ytp-chrome-bottom, .ytp-chapter-hover-container {


### PR DESCRIPTION
Youtube must have made the video player scale to cover instead of contain recently. This caused the video to be cut off when using the true theater mode. 