### PR TITLE
Changes so your cursor turns into a pointer for the YouTube 7TV emote button

### DIFF
--- a/src/Style/Style.scss
+++ b/src/Style/Style.scss
@@ -219,6 +219,7 @@ div[id="content"]
   		width: 100%;
   		height: 100%;
 		mask-size: contain;
+		cursor: pointer;
   		-webkit-mask-size: contain;
 	}
 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/18615981/167161234-d3f4d73c-70ed-47a3-a570-cd7419fa2c76.png)

After:
![image](https://user-images.githubusercontent.com/18615981/167161167-d422b4fe-3bd2-4ba9-8225-cd7d23056850.png)

I don't know about you, but it has been infuriating me since the first moments 7TV started to work on YouTube.