### PR TITLE
Filter out missing urls

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # 7TV Web Extension - Changelog
 
+### Version 2.2.3
+
+- Twitch: Fixed an issue with some low resolution emotes
+
 ### Version 2.2.2
 
 - YouTube: Fixed an issue causing the true theater mode to cut off the video/stream (#258)

--- a/src/Global/API.ts
+++ b/src/Global/API.ts
@@ -133,7 +133,7 @@ export class API {
 				['2', emote.urls['2']],
 				['3', emote.urls['4']],
 				['4', emote.urls['4']],
-			],
+			].filter(([_, url]) => !!url) as [string, string][],
 			owner: emote?.owner ? {
 				id: emote?.id,
 				login: emote.owner?.name,

--- a/src/Global/EmoteStore.tsx
+++ b/src/Global/EmoteStore.tsx
@@ -405,8 +405,8 @@ export namespace EmoteStore {
 			img.classList.add('chat-image');
 			img.classList.add('chat-line__message--emote');
 			img.src = this.cdn('1');
-			img.srcset = `${this.cdn('1')} 1x, ${this.cdn('2')} 2x, ${this.cdn('4')} 4x`;
-
+			// Filter out 3x
+			img.srcset = this.urls.filter(([size]) => size != '3').map(([size, url]) => `${url} ${size}x`).join(', ');
 			inner.appendChild(img);
 			container.appendChild(inner);
 			return this.element = container;


### PR DESCRIPTION
Some FFZ emotes only provide a 1x resolution. This filters both the Emote object and patches the rendering.
Fixes #252 