### PR TITLE
Temporary workaround to messages sendt by the user being rerendered.

### DIFF
--- a/src/Sites/twitch.tv/Util/MessagePatcher.tsx
+++ b/src/Sites/twitch.tv/Util/MessagePatcher.tsx
@@ -99,7 +99,9 @@ export class MessagePatcher {
 		// Send message data back to the content script
 		line.element.id = `7TV#msg:${message.id}`; // Give an ID to the message element
 		line.element.setAttribute('seventv-id', message.id);
-		this.msg.seventv.patcher = null;
+
+		// Don't clear the patcher as a temporary workaround to twitch rerendering the most recent message
+		//this.msg.seventv.patcher = null;
 
 		const renderer = new MessageRenderer(this.page.site, message, line.element.id);
 


### PR DESCRIPTION
This fixes the rerendering of messages send by the user. Not sure of the implications of not clearing the patcher, but dosn't seem to break anything immediately. Not including changelog in case you want to improve upon this. Ill be gone for most of the rest of the day.