### PR TITLE
Settings UI rework

### DIFF
--- a/src/Sites/app/MainComponent.tsx
+++ b/src/Sites/app/MainComponent.tsx
@@ -7,7 +7,7 @@ import { EmoteStore } from 'src/Global/EmoteStore';
 import { theme } from 'src/Global/Util';
 import styled from 'styled-components';
 import { ThemeProvider } from '@material-ui/core/styles';
-import { SettingsComponent } from 'src/Sites/app/Settings/SettingsComponent';
+import SettingsComponent from './Settings/SettingsComponent';
 import { settings } from 'src/Content/Runtime/Settings';
 import { settingNodes, SiteApp } from 'src/Sites/app/SiteApp';
 

--- a/src/Sites/app/Settings/Inputs/Checkbox.tsx
+++ b/src/Sites/app/Settings/Inputs/Checkbox.tsx
@@ -4,6 +4,25 @@ import { MainComponent } from 'src/Sites/app/MainComponent';
 import { SettingNode } from 'src/Content/Runtime/Settings';
 import { SettingValue } from 'src/Global/Util';
 
+const formControlLabelStyle = {
+	'.MuiFormControlLabel-label': {
+		fontSize: '1em',
+		color: 'currentcolor'
+	},
+	'.MuiButtonBase-root': {
+		color: 'currentcolor'
+	}
+};
+
+const checkboxStyle = {
+	paddingTop: 0,
+	paddingBottom: 0,
+	'& .MuiSvgIcon-root': {
+		fontSize: 24,
+		marginLeft: '14px'
+	}
+}
+
 const Checkbox: React.FC<Checkbox.Props> = ({ main, id, label, defaultValue }) => {
 	const handleChange = (ev: React.ChangeEvent<HTMLInputElement>): void => {
 		const checked = ev.target.checked;
@@ -15,11 +34,11 @@ const Checkbox: React.FC<Checkbox.Props> = ({ main, id, label, defaultValue }) =
 	};
 
   return (
-    <FormControlLabel label={label} sx={{ '.MuiFormControlLabel-label': { fontSize: '1em', color: 'currentcolor' }, '.MuiButtonBase-root': { color: 'currentcolor' } }} control={
+    <FormControlLabel label={label} sx={formControlLabelStyle} control={
       <MUICheckbox
         checked={(main.app?.config.get(id)?.asBoolean() ?? defaultValue) as boolean}
         onChange={handleChange}
-        sx={{ '& .MuiSvgIcon-root': { fontSize: 24, marginLeft: '14px' } }} />
+        sx={checkboxStyle} />
     } />
   );
 }

--- a/src/Sites/app/Settings/Inputs/Checkbox.tsx
+++ b/src/Sites/app/Settings/Inputs/Checkbox.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { FormControlLabel, Checkbox as MUICheckbox } from '@material-ui/core';
+import { MainComponent } from 'src/Sites/app/MainComponent';
+import { SettingNode } from 'src/Content/Runtime/Settings';
+import { SettingValue } from 'src/Global/Util';
+
+const Checkbox: React.FC<Checkbox.Props> = ({ main, id, label, defaultValue }) => {
+	const handleChange = (ev: React.ChangeEvent<HTMLInputElement>): void => {
+		const checked = ev.target.checked;
+
+		main.app?.config.set(id, new SettingValue(checked));
+		main.app?.sendMessageUp('SetConfigNode', { key: `cfg.${id}`, value: checked });
+
+		main.setState({});
+	};
+
+  return (
+    <FormControlLabel label={label} sx={{ '.MuiFormControlLabel-label': { fontSize: '1em', color: 'currentcolor' }, '.MuiButtonBase-root': { color: 'currentcolor' } }} control={
+      <MUICheckbox
+        checked={(main.app?.config.get(id)?.asBoolean() ?? defaultValue) as boolean}
+        onChange={handleChange}
+        sx={{ '& .MuiSvgIcon-root': { fontSize: 24, marginLeft: '14px' } }} />
+    } />
+  );
+}
+
+export default Checkbox;
+
+export namespace Checkbox {
+	export interface Props extends SettingNode {
+		main: MainComponent;
+	}
+}

--- a/src/Sites/app/Settings/Inputs/Select.tsx
+++ b/src/Sites/app/Settings/Inputs/Select.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { FormControlLabel, FormLabel, RadioGroup, Radio } from '@material-ui/core';
+import { MainComponent } from 'src/Sites/app/MainComponent';
+import { SettingNode } from 'src/Content/Runtime/Settings';
+import { SettingValue } from 'src/Global/Util';
+
+const Select: React.FC<Select.Props> = ({ main, id, label, defaultValue, options }) => {
+	const handleChange = (ev: React.ChangeEvent<HTMLInputElement>): void => {
+		const value = ev.target.value;
+
+		main.app?.config.set(id, new SettingValue(value));
+		main.app?.sendMessageUp('SetConfigNode', { key: `cfg.${id}`, value: value });
+
+		main.setState({});
+	};
+
+  return (
+    <div>
+			<FormLabel component='legend' style={{ fontSize: '1em', color: 'currentcolor', margin: '14px 0 0 14px'}}>{label}</FormLabel>
+			<RadioGroup
+				style={{ marginLeft: '14px'}}
+				name='Test'
+				sx={{ '.MuiFormControlLabel-label': { fontSize: '1em', color: 'currentcolor' }, '.MuiButtonBase-root': { color: 'currentcolor' }}}
+				onChange={handleChange}
+				value={(main.app?.config.get(id)?.asString() ?? defaultValue) as string}>
+					{options?.map((option) => (
+						<FormControlLabel style={{textTransform:'capitalize'}} value={option} key={option} control={<Radio />} label={option} />
+					))}
+			</RadioGroup>
+		</div>
+  );
+}
+
+export default Select;
+
+export namespace Select {
+	export interface Props extends SettingNode {
+		main: MainComponent;
+	}
+}

--- a/src/Sites/app/Settings/Inputs/Select.tsx
+++ b/src/Sites/app/Settings/Inputs/Select.tsx
@@ -1,11 +1,28 @@
 import React from 'react';
-import { FormControlLabel, FormLabel, RadioGroup, Radio } from '@material-ui/core';
+import { Select as MUISelect, MenuItem, SelectChangeEvent, Typography } from '@material-ui/core';
 import { MainComponent } from 'src/Sites/app/MainComponent';
 import { SettingNode } from 'src/Content/Runtime/Settings';
 import { SettingValue } from 'src/Global/Util';
+import { SxProps } from '@material-ui/system';
+
+const menuProps = {
+	disablePortal: true,
+	MenuListProps: {
+		sx: {
+			backgroundColor: 'var(--seventv-color-background-1)'
+		}
+	}
+};
+
+const menuItemStyle: SxProps = {
+	textTransform: 'capitalize',
+	'&.Mui-selected': {
+		backgroundColor: 'var(--seventv-primary-color)'
+	}
+};
 
 const Select: React.FC<Select.Props> = ({ main, id, label, defaultValue, options }) => {
-	const handleChange = (ev: React.ChangeEvent<HTMLInputElement>): void => {
+	const handleChange = (ev: SelectChangeEvent<any>): void => {
 		const value = ev.target.value;
 
 		main.app?.config.set(id, new SettingValue(value));
@@ -15,18 +32,20 @@ const Select: React.FC<Select.Props> = ({ main, id, label, defaultValue, options
 	};
 
   return (
-    <div>
-			<FormLabel component='legend' style={{ fontSize: '1em', color: 'currentcolor', margin: '14px 0 0 14px'}}>{label}</FormLabel>
-			<RadioGroup
-				style={{ marginLeft: '14px'}}
-				name='Test'
-				sx={{ '.MuiFormControlLabel-label': { fontSize: '1em', color: 'currentcolor' }, '.MuiButtonBase-root': { color: 'currentcolor' }}}
+		<div className='seventv-sm-option-select'>
+			<Typography variant='body1' sx={{ fontSize: '1em' }} className='seventv-sm-select-label'>{label}</Typography>
+			<MUISelect
+				value={main.app?.config.get(id)?.asString() ?? defaultValue ?? ''}
 				onChange={handleChange}
-				value={(main.app?.config.get(id)?.asString() ?? defaultValue) as string}>
-					{options?.map((option) => (
-						<FormControlLabel style={{textTransform:'capitalize'}} value={option} key={option} control={<Radio />} label={option} />
-					))}
-			</RadioGroup>
+				sx={{ minWidth: '100px', textTransform: 'capitalize' }}
+				SelectDisplayProps={{ style: { fontSize: '1.2em', marginBottom: '-3px' } }}
+				MenuProps={menuProps}>
+				{options?.map(option => (
+					<MenuItem key={option} value={option} sx={menuItemStyle}>
+						{option}
+					</MenuItem>
+				))}
+			</MUISelect>
 		</div>
   );
 }

--- a/src/Sites/app/Settings/SettingsComponent.tsx
+++ b/src/Sites/app/Settings/SettingsComponent.tsx
@@ -44,7 +44,7 @@ const SettingsComponent: React.FC<SettingsComponent.Props> = ({ main, settings }
 						</div>
 					</div>
 					<IconButton title='Close settings' onClick={() => main.setState({ settingsMenu: { open: false } })}>
-						<CloseIcon sx={{ fontSize: 32, color: 'red' }} />
+						<CloseIcon sx={{ fontSize: 28, color: '#747474' }} />
 					</IconButton>
 				</div>
 			</div>

--- a/src/Sites/app/Settings/SettingsComponent.tsx
+++ b/src/Sites/app/Settings/SettingsComponent.tsx
@@ -4,6 +4,7 @@ import { Config } from 'src/Config';
 import { SettingNode } from 'src/Content/Runtime/Settings';
 import { SettingsForm } from 'src/Sites/app/Settings/SettingsForm';
 import { assetStore, SiteApp } from 'src/Sites/app/SiteApp';
+import { IconButton } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
 import React from 'react';
 
@@ -21,52 +22,43 @@ export class SettingsComponent extends React.Component<SettingsComponent.Props> 
 
 		return (
 			<div className={`seventv-settings-menu ${this.site.config.get('ui.transparency')?.asBoolean() ? 'seventv-sm-backdrop-blur' : ''}`}>
-				<div className='seventv-sm-sidebar'>
-					{/* Logo */}
-					<div className='seventv-sm-logo'>
-						<img src={logoURL} width={96} height={96}></img>
+				{/* Header */}
+				<div className='seventv-sm-header'>
+					<div className='seventv-sm-header-left'>
+						<img src={logoURL} />
+						<h1 className='seventv-sm-title'>Settings</h1>
 					</div>
-
-					{/* Tabs List */}
-					<div className='seventv-sm-tabs'>
-						<div className='seventv-sm-tablist'></div>
+					<div className='seventv-sm-header-right'>
 						<div className='seventv-sm-socials'>
-							<span>Join The Community</span>
-
+							<span className='seventv-sm-cta'>Join The Community</span>
 							<div className='seventv-sm-social-list'>
-								{this.socials.map(soc =>
-									<div key={`social-${soc.label}`} className='seventv-sm-social-icon' onClick={() => window.open(soc.clickURL, '_blank')}>
-										<img src={soc.imageURL}></img>
-									</div>
+								{this.socials.map(x =>
+									<IconButton key={x.label} className='seventv-sm-social-icon' onClick={() => window.open(x.clickURL, '_blank')} title={`7TV ${x.label}`}>
+										<img src={x.imageURL} />
+									</IconButton>
 								)}
 							</div>
 						</div>
-						<div className='seventv-sm-appinfo'>
-							<span>Version: {version}</span>
-							<span>Server: {Config.apiUrl}</span>
+						<IconButton title='Close settings' onClick={() => this.props.main.setState({ settingsMenu: { open: false } })}>
+							<CloseIcon sx={{ fontSize: 32, color: 'red' }} />
+						</IconButton>
+					</div>
+				</div>
+
+				{/* Content */}
+				<div className='seventv-sm-content'>
+					<div className='seventv-sm-options'>
+						<div className='form-list'>
+							<SettingsForm main={this.props.main} settings={this.props.settings} />
 						</div>
 					</div>
 				</div>
 
-				<div className='seventv-sm-content'>
-					{/** Heading & Breadcrumbs */}
-					<div className='seventv-sm-heading'>
-						<div className='seventv-sm-titlebox'>
-							<span>Settings</span>
-						</div>
-
-						<div className='close-icon' onClick={() => this.props.main.setState({ settingsMenu: { open: false } })}>
-							<CloseIcon sx={{ fontSize: 32, color: 'red' }}></CloseIcon>
-						</div>
-					</div>
-
-					<div className='seventv-sm-options'>
-						<span></span>
-
-						{/** Render the form */}
-						<div className='form-list'>
-							<SettingsForm main={this.props.main} settings={this.props.settings}></SettingsForm>
-						</div>
+				{/* Footer */}
+				<div className='seventv-sm-footer'>
+					<div className='seventv-sm-appinfo'>
+						<span>Version: {version}</span>
+						<span>Server: {Config.apiUrl}</span>
 					</div>
 				</div>
 			</div>
@@ -85,7 +77,7 @@ export class SettingsComponent extends React.Component<SettingsComponent.Props> 
 			imageURL: assetStore.get('twitter.webp')
 		}
 	] as SettingsComponent.SocialIcon[];
-}
+};
 
 export namespace SettingsComponent {
 	export interface Props {

--- a/src/Sites/app/Settings/SettingsComponent.tsx
+++ b/src/Sites/app/Settings/SettingsComponent.tsx
@@ -1,71 +1,17 @@
-import { MainComponent } from 'src/Sites/app/MainComponent';
+import React from 'react';
+import { MainComponent } from '../MainComponent';
+import { assetStore, SiteApp } from '../SiteApp';
 import { version } from 'public/manifest.v3.json';
 import { Config } from 'src/Config';
 import { SettingNode } from 'src/Content/Runtime/Settings';
-import { SettingsForm } from 'src/Sites/app/Settings/SettingsForm';
-import { assetStore, SiteApp } from 'src/Sites/app/SiteApp';
+import SettingsForm from './SettingsForm';
 import { IconButton } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
-import React from 'react';
 
-export class SettingsComponent extends React.Component<SettingsComponent.Props> {
-	constructor(props: SettingsComponent.Props) {
-		super(props);
-	}
-
-	get site(): SiteApp {
-		return this.props.main.app as SiteApp;
-	}
-
-	render() {
-		const logoURL = assetStore.get('7tv.webp');
-
-		return (
-			<div className={`seventv-settings-menu ${this.site.config.get('ui.transparency')?.asBoolean() ? 'seventv-sm-backdrop-blur' : ''}`}>
-				{/* Header */}
-				<div className='seventv-sm-header'>
-					<div className='seventv-sm-header-left'>
-						<img src={logoURL} />
-						<h1 className='seventv-sm-title'>Settings</h1>
-					</div>
-					<div className='seventv-sm-header-right'>
-						<div className='seventv-sm-socials'>
-							<span className='seventv-sm-cta'>Join The Community</span>
-							<div className='seventv-sm-social-list'>
-								{this.socials.map(x =>
-									<IconButton key={x.label} className='seventv-sm-social-icon' onClick={() => window.open(x.clickURL, '_blank')} title={`7TV ${x.label}`}>
-										<img src={x.imageURL} />
-									</IconButton>
-								)}
-							</div>
-						</div>
-						<IconButton title='Close settings' onClick={() => this.props.main.setState({ settingsMenu: { open: false } })}>
-							<CloseIcon sx={{ fontSize: 32, color: 'red' }} />
-						</IconButton>
-					</div>
-				</div>
-
-				{/* Content */}
-				<div className='seventv-sm-content'>
-					<div className='seventv-sm-options'>
-						<div className='form-list'>
-							<SettingsForm main={this.props.main} settings={this.props.settings} />
-						</div>
-					</div>
-				</div>
-
-				{/* Footer */}
-				<div className='seventv-sm-footer'>
-					<div className='seventv-sm-appinfo'>
-						<span>Version: {version}</span>
-						<span>Server: {Config.apiUrl}</span>
-					</div>
-				</div>
-			</div>
-		);
-	}
-
-	socials = [
+const SettingsComponent: React.FC<SettingsComponent.Props> = ({ main, settings }) => {
+	const site: SiteApp = main.app as SiteApp;
+	const logoURL = assetStore.get('7tv.webp');
+	const socials = [
 		{
 			label: 'Discord',
 			clickURL: `https://discord.gg/${Config.social.discordInviteID}`,
@@ -77,7 +23,53 @@ export class SettingsComponent extends React.Component<SettingsComponent.Props> 
 			imageURL: assetStore.get('twitter.webp')
 		}
 	] as SettingsComponent.SocialIcon[];
+
+	return (
+		<div className={`seventv-settings-menu ${site.config.get('ui.transparency')?.asBoolean() ? 'seventv-sm-backdrop-blur' : ''}`}>
+			{/* Header */}
+			<div className='seventv-sm-header'>
+				<div className='seventv-sm-header-left'>
+					<img src={logoURL} />
+					<h1 className='seventv-sm-title'>Settings</h1>
+				</div>
+				<div className='seventv-sm-header-right'>
+					<div className='seventv-sm-socials'>
+						<span className='seventv-sm-cta'>Join The Community</span>
+						<div className='seventv-sm-social-list'>
+							{socials.map(x =>
+								<IconButton key={x.label} className='seventv-sm-social-icon' onClick={() => window.open(x.clickURL, '_blank')} title={`7TV ${x.label}`}>
+									<img src={x.imageURL} />
+								</IconButton>
+							)}
+						</div>
+					</div>
+					<IconButton title='Close settings' onClick={() => main.setState({ settingsMenu: { open: false } })}>
+						<CloseIcon sx={{ fontSize: 32, color: 'red' }} />
+					</IconButton>
+				</div>
+			</div>
+
+			{/* Content */}
+			<div className='seventv-sm-content'>
+				<div className='seventv-sm-options'>
+					<div className='form-list'>
+						<SettingsForm main={main} settings={settings} />
+					</div>
+				</div>
+			</div>
+
+			{/* Footer */}
+			<div className='seventv-sm-footer'>
+				<div className='seventv-sm-appinfo'>
+					<span>Version: {version}</span>
+					<span>Server: {Config.apiUrl}</span>
+				</div>
+			</div>
+		</div>
+	);
 };
+
+export default SettingsComponent;
 
 export namespace SettingsComponent {
 	export interface Props {

--- a/src/Sites/app/Settings/SettingsForm.tsx
+++ b/src/Sites/app/Settings/SettingsForm.tsx
@@ -3,7 +3,7 @@ import {
 	FormGroup,
 	FormControl,
 	FormHelperText,
-	OutlinedInput
+	OutlinedInput,
 } from '@material-ui/core';
 import { SettingNode } from 'src/Content/Runtime/Settings';
 import { MainComponent } from 'src/Sites/app/MainComponent';
@@ -14,6 +14,7 @@ const SettingsForm: React.FC<SettingsForm.Props> = ({ main, settings }) => (
 	<FormGroup>
 		{settings.map(setting => {
 			let input: JSX.Element;
+			let controlProps = {};
 
 			switch (setting.type) {
 				case 'checkbox':
@@ -21,6 +22,7 @@ const SettingsForm: React.FC<SettingsForm.Props> = ({ main, settings }) => (
 					break;
 				case 'select':
 					input = <Select main={main} {...setting} />;
+					controlProps = { size: 'small' };
 					break;
 				default:
 					input = <OutlinedInput placeholder='Generic Input' />;
@@ -29,11 +31,12 @@ const SettingsForm: React.FC<SettingsForm.Props> = ({ main, settings }) => (
 
 			return (
 				<FormControl
+					key={`formcontrol-${setting.id}`}
 					disabled={setting.disabledIf?.() || false}
 					component='fieldset'
-					sx={{ '.Mui-disabled': { color: 'red' }}}
-					key={`formcontrol-${setting.id}`}
-					id={setting.id}>
+					sx={{ '.Mui-disabled': { color: 'red' }, marginBottom: '18px' }}
+					id={setting.id}
+					{...controlProps}>
 						{input}
 						<FormHelperText style={{ fontSize: '0.75em', color: 'currentcolor', opacity: '0.60' }}> {setting.hint} </FormHelperText>
 				</FormControl>

--- a/src/Sites/app/Settings/SettingsForm.tsx
+++ b/src/Sites/app/Settings/SettingsForm.tsx
@@ -2,90 +2,45 @@ import React from 'react';
 import {
 	FormGroup,
 	FormControl,
-	FormControlLabel,
 	FormHelperText,
-	FormLabel,
-	Checkbox,
-	RadioGroup,
-	Radio,
 	OutlinedInput
 } from '@material-ui/core';
 import { SettingNode } from 'src/Content/Runtime/Settings';
 import { MainComponent } from 'src/Sites/app/MainComponent';
-import { SettingValue } from 'src/Global/Util';
+import Checkbox from './Inputs/Checkbox';
+import Select from './Inputs/Select';
 
-const SettingsForm: React.FC<SettingsForm.Props> = ({ main, settings }) => {
-	const handleCheckboxChange = (sNode: SettingNode, ev: React.ChangeEvent<HTMLInputElement>): void => {
-		const checked = ev.target.checked;
+const SettingsForm: React.FC<SettingsForm.Props> = ({ main, settings }) => (
+	<FormGroup>
+		{settings.map(setting => {
+			let input: JSX.Element;
 
-		sNode.value = checked;
-		main.app?.config.set(sNode.id, new SettingValue(checked));
-		main.app?.sendMessageUp('SetConfigNode', { key: `cfg.${sNode.id}`, value: checked });
+			switch (setting.type) {
+				case 'checkbox':
+					input = <Checkbox main={main} {...setting} />;
+					break;
+				case 'select':
+					input = <Select main={main} {...setting} />;
+					break;
+				default:
+					input = <OutlinedInput placeholder='Generic Input' />;
+					break;
+			}
 
-		main.setState({});
-	};
-
-	const handleSelectChange = (sNode: SettingNode, ev: React.ChangeEvent<HTMLInputElement>): void => {
-		const value = ev.target.value;
-
-		sNode.value = value;
-		main.app?.config.set(sNode.id, new SettingValue(value));
-		main.app?.sendMessageUp('SetConfigNode', { key: `cfg.${sNode.id}`, value });
-
-		main.setState({});
-	};
-
-	return (
-		<FormGroup>
-			{settings.map(setting => {
-				let input: JSX.Element;
-
-				switch (setting.type) {
-					case 'checkbox':
-						input =
-							<FormControlLabel label={setting.label} sx={{ '.MuiFormControlLabel-label': { fontSize: '1em', color: 'currentcolor' }, '.MuiButtonBase-root': { color: 'currentcolor' } }} control={
-								<Checkbox
-									checked={(main.app?.config.get(setting.id)?.asBoolean() ?? setting.defaultValue) as boolean}
-									onChange={ev => handleCheckboxChange(setting, ev)}
-									sx={{ '& .MuiSvgIcon-root': { fontSize: 24, marginLeft: '14px' } }} />
-							} />;
-						break;
-					case 'select':
-						input =
-							<div>
-								<FormLabel component='legend' style={{ fontSize: '1em', color: 'currentcolor', margin: '14px 0 0 14px'}}>{setting.label}</FormLabel>
-								<RadioGroup
-									style={{ marginLeft: '14px'}}
-									name='Test'
-									sx={{ '.MuiFormControlLabel-label': { fontSize: '1em', color: 'currentcolor' }, '.MuiButtonBase-root': { color: 'currentcolor' } }}
-									onChange={ev => handleSelectChange(setting, ev)}
-									value={(main.app?.config.get(setting.id)?.asString() ?? setting.defaultValue) as string}>
-										{setting.options?.map((option) => (
-											<FormControlLabel style={{textTransform:'capitalize'}} value={option} key={option} control={<Radio />} label={option} />
-										))}
-								</RadioGroup>
-							</div>;
-						break;
-					default:
-						input = <OutlinedInput placeholder='Generic Input' />;
-						break;
-				}
-
-				return (
-					<FormControl
-						disabled={setting.disabledIf?.() || false}
-						component='fieldset'
-						sx={{ '.Mui-disabled': { color: 'red' }}}
-						key={`formcontrol-${setting.id}`}
-						id={setting.id}>
-							{input}
-							<FormHelperText style={{ fontSize: '0.75em', color: 'currentcolor', opacity: '0.60' }}> {setting.hint} </FormHelperText>
-					</FormControl>
-				)
-			})}
-		</FormGroup>
-	);
-}
+			return (
+				<FormControl
+					disabled={setting.disabledIf?.() || false}
+					component='fieldset'
+					sx={{ '.Mui-disabled': { color: 'red' }}}
+					key={`formcontrol-${setting.id}`}
+					id={setting.id}>
+						{input}
+						<FormHelperText style={{ fontSize: '0.75em', color: 'currentcolor', opacity: '0.60' }}> {setting.hint} </FormHelperText>
+				</FormControl>
+			)
+		})}
+	</FormGroup>
+);
 
 export default SettingsForm;
 

--- a/src/Sites/app/Settings/SettingsForm.tsx
+++ b/src/Sites/app/Settings/SettingsForm.tsx
@@ -1,85 +1,93 @@
 import React from 'react';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Checkbox from '@material-ui/core/Checkbox';
-import Input from '@material-ui/core/OutlinedInput';
-import FormControl from '@material-ui/core/FormControl';
-import FormHelperText from '@material-ui/core/FormHelperText';
-import FormGroup from '@material-ui/core/FormGroup';
-import FormLabel from '@material-ui/core/FormLabel';
-import RadioGroup from '@material-ui/core/RadioGroup';
-import Radio from '@material-ui/core/Radio';
+import {
+	FormGroup,
+	FormControl,
+	FormControlLabel,
+	FormHelperText,
+	FormLabel,
+	Checkbox,
+	RadioGroup,
+	Radio,
+	OutlinedInput
+} from '@material-ui/core';
 import { SettingNode } from 'src/Content/Runtime/Settings';
 import { MainComponent } from 'src/Sites/app/MainComponent';
 import { SettingValue } from 'src/Global/Util';
 
-export class SettingsForm extends React.Component<SettingsForm.Props> {
-	render() {
-		return (
-			<FormGroup>
-				{this.props.settings.map(s => {
-					const isDisabled = typeof s.disabledIf === 'function' ? s.disabledIf() : false;
-					let result: JSX.Element;
-					switch (s.type) {
-						case 'checkbox':
-							result =
-								<FormControlLabel label={s.label} sx={{ '.MuiFormControlLabel-label': { fontSize: '1em', color: 'currentcolor' }, '.MuiButtonBase-root': { color: 'currentcolor' } }} control={
-									<Checkbox
-										checked={(this.props.main.app?.config.get(s.id)?.asBoolean() ?? s.defaultValue) as boolean}
-										onChange={ev => this.handleCheckboxChange(s, ev)}
-										sx={{ '& .MuiSvgIcon-root': { fontSize: 24, marginLeft: '14px' } }} />
-								}></FormControlLabel>;
-							break;
-
-
-						case 'select':
-							result =
-								<div>
-									<FormLabel component='legend' style={{ fontSize: '1em', color: 'currentcolor', margin: '14px 0 0 14px'}}>{s.label}</FormLabel>
-									<RadioGroup style={{ marginLeft: '14px'}} name='Test' sx={{ '.MuiFormControlLabel-label': { fontSize: '1em', color: 'currentcolor' }, '.MuiButtonBase-root': { color: 'currentcolor' } }} onChange={ev => this.handleSelectChange(s, ev)} value={(this.props.main.app?.config.get(s.id)?.asString() ?? s.defaultValue) as string}>
-											{s.options?.map((option) => <FormControlLabel style={{textTransform:'capitalize'}} value={option} key={option} control={<Radio />} label={option} /> )}
-									</RadioGroup>
-								</div>;
-							break;
-
-						default:
-							result =
-								<Input placeholder='Generic Input'></Input>;
-							break;
-					}
-
-					return <FormControl disabled={isDisabled} component='fieldset' sx={{
-						'.Mui-disabled': { color: 'red' }
-					}} key={`formcontrol-${s.id}`} id={s.id}>
-						{result}
-						<FormHelperText style={{ fontSize: '0.75em', color: 'currentcolor', opacity: '0.60' }}> {s.hint} </FormHelperText>
-					</FormControl>;
-				})}
-			</FormGroup>
-		);
-	}
-
-	handleCheckboxChange(sNode: SettingNode, ev: React.ChangeEvent<HTMLInputElement>): void {
+const SettingsForm: React.FC<SettingsForm.Props> = ({ main, settings }) => {
+	const handleCheckboxChange = (sNode: SettingNode, ev: React.ChangeEvent<HTMLInputElement>): void => {
 		const checked = ev.target.checked;
 
 		sNode.value = checked;
-		this.props.main.app?.config.set(sNode.id, new SettingValue(checked));
-		this.props.main.app?.sendMessageUp('SetConfigNode', { key: `cfg.${sNode.id}`, value: checked });
+		main.app?.config.set(sNode.id, new SettingValue(checked));
+		main.app?.sendMessageUp('SetConfigNode', { key: `cfg.${sNode.id}`, value: checked });
 
-		this.setState({});
-		this.props.main.setState({});
-	}
+		main.setState({});
+	};
 
-	handleSelectChange(sNode: SettingNode, ev: any): void {
+	const handleSelectChange = (sNode: SettingNode, ev: React.ChangeEvent<HTMLInputElement>): void => {
 		const value = ev.target.value;
 
 		sNode.value = value;
-		this.props.main.app?.config.set(sNode.id, new SettingValue(value));
-		this.props.main.app?.sendMessageUp('SetConfigNode', { key: `cfg.${sNode.id}`, value: value });
+		main.app?.config.set(sNode.id, new SettingValue(value));
+		main.app?.sendMessageUp('SetConfigNode', { key: `cfg.${sNode.id}`, value });
 
-		this.setState({});
-		this.props.main.setState({});
-	}
+		main.setState({});
+	};
+
+	return (
+		<FormGroup>
+			{settings.map(setting => {
+				let input: JSX.Element;
+
+				switch (setting.type) {
+					case 'checkbox':
+						input =
+							<FormControlLabel label={setting.label} sx={{ '.MuiFormControlLabel-label': { fontSize: '1em', color: 'currentcolor' }, '.MuiButtonBase-root': { color: 'currentcolor' } }} control={
+								<Checkbox
+									checked={(main.app?.config.get(setting.id)?.asBoolean() ?? setting.defaultValue) as boolean}
+									onChange={ev => handleCheckboxChange(setting, ev)}
+									sx={{ '& .MuiSvgIcon-root': { fontSize: 24, marginLeft: '14px' } }} />
+							} />;
+						break;
+					case 'select':
+						input =
+							<div>
+								<FormLabel component='legend' style={{ fontSize: '1em', color: 'currentcolor', margin: '14px 0 0 14px'}}>{setting.label}</FormLabel>
+								<RadioGroup
+									style={{ marginLeft: '14px'}}
+									name='Test'
+									sx={{ '.MuiFormControlLabel-label': { fontSize: '1em', color: 'currentcolor' }, '.MuiButtonBase-root': { color: 'currentcolor' } }}
+									onChange={ev => handleSelectChange(setting, ev)}
+									value={(main.app?.config.get(setting.id)?.asString() ?? setting.defaultValue) as string}>
+										{setting.options?.map((option) => (
+											<FormControlLabel style={{textTransform:'capitalize'}} value={option} key={option} control={<Radio />} label={option} />
+										))}
+								</RadioGroup>
+							</div>;
+						break;
+					default:
+						input = <OutlinedInput placeholder='Generic Input' />;
+						break;
+				}
+
+				return (
+					<FormControl
+						disabled={setting.disabledIf?.() || false}
+						component='fieldset'
+						sx={{ '.Mui-disabled': { color: 'red' }}}
+						key={`formcontrol-${setting.id}`}
+						id={setting.id}>
+							{input}
+							<FormHelperText style={{ fontSize: '0.75em', color: 'currentcolor', opacity: '0.60' }}> {setting.hint} </FormHelperText>
+					</FormControl>
+				)
+			})}
+		</FormGroup>
+	);
 }
+
+export default SettingsForm;
 
 export namespace SettingsForm {
 	export interface Props {

--- a/src/Style/Components/Settings.scss
+++ b/src/Style/Components/Settings.scss
@@ -1,4 +1,6 @@
 $borderRadius: 8px;
+$space-s: 10px;
+$space-m: 25px;
 
 .seventv-settings-menu {
 	width: 80vw;
@@ -6,6 +8,7 @@ $borderRadius: 8px;
 	pointer-events: all;
 	border-radius: $borderRadius;
 	max-width: 96em;
+	overflow: hidden;
 
 	background-color: var(--seventv-color-background-0);
 	&.seventv-sm-backdrop-blur {
@@ -14,46 +17,42 @@ $borderRadius: 8px;
 	}
 
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
 
-	.seventv-sm-sidebar {
+	.seventv-sm-header {
 		display: flex;
-		flex-direction: column;
-		height: 100%;
-		width: 20rem;
-		flex-grow: 0;
+		justify-content: space-between;
+		align-items: center;
+		height: 5rem;
+		padding: $space-s $space-m;
 		background-color: var(--seventv-color-background-1);
-		border-bottom-left-radius: $borderRadius;
 
-		.seventv-sm-logo {
-			background-color: var(--seventv-color-background-0);
-			border-bottom-right-radius: 3em;
-			height: min-content;
-			width: 10rem;
+		.seventv-sm-header-left {
+			height: 100%;
+			display: flex;
+			align-items: center;
+
+			img {
+				height: 100%;
+				margin-right: $space-s;
+			}
+
+			.seventv-sm-title {
+				font-size: 2.5rem;
+			}
 		}
 
-		.seventv-sm-tabs {
+		.seventv-sm-header-right {
 			display: flex;
-			flex-direction: column;
-			align-content: space-between;
-			height: 100%;
-
-			.seventv-sm-tablist {
-				display: flex;
-				flex-grow: 1;
-			}
 
 			.seventv-sm-socials {
 				display: flex;
-				flex-direction: column;
-				justify-content: center;
-				margin-left: 1em;
-				margin-right: 1em;
-				margin-bottom: 3em;
+				align-items: center;
+				padding: 0px $space-s;
+				margin-right: $space-m;
 
-				span {
-					text-align: center;
-					margin-bottom: 1em;
+				.seventv-sm-cta {
+					margin-right: $space-s;
 				}
 
 				.seventv-sm-social-list {
@@ -61,65 +60,27 @@ $borderRadius: 8px;
 					align-items: center;
 					justify-content: space-around;
 				}
+
 				.seventv-sm-social-icon {
-					display: block;
-					padding-right: 1em;
-					padding-left: 1em;
 					cursor: pointer;
 
 					img {
-						width: 4rem;
-						height: 4rem;
+						width: 3rem;
+						height: 3rem;
 					}
 				}
 			}
-	
-			.seventv-sm-appinfo {
+			
+			.close-icon {
+				cursor: pointer;
 				display: flex;
-				flex-direction: column;
-				flex-shrink: 1;
-				flex-wrap: wrap;
-				text-align: center;
-				justify-content: center;
-				margin-bottom: 1em;
-
-				span {
-					font-size: .95rem;
-				}
+				align-items: center;
 			}
 		}
 	}
 
 	.seventv-sm-content {
-		display: flex;
-		flex-direction: column;
-		flex-grow: 1;
-		height: 100%;
-		width: 100%;
-
-		.seventv-sm-heading {
-			display: flex;
-			justify-content: space-between;
-			align-items: center;
-			height: 4.8rem;
-			width: 100%;
-			background-color: var(--seventv-color-background-1);
-			backdrop-filter: blur(1rem);
-			border-top-right-radius: $borderRadius;
-
-			.seventv-sm-titlebox {
-				display: flex;
-
-				span {
-					margin-left: .1em;
-					font-size: 2em;
-				}
-			}
-
-			.close-icon {
-				cursor: pointer;
-			}
-		}
+		overflow-y: scroll;
 
 		.seventv-sm-options {
 			overflow: auto;
@@ -128,6 +89,25 @@ $borderRadius: 8px;
 
 			.form-list {
 				padding: 1em;
+			}
+		}
+	}
+
+	.seventv-sm-footer {
+		display: flex;
+		justify-content: end;
+		align-items: center;
+		height: 3rem;
+		padding: $space-s $space-m;
+		background-color: var(--seventv-color-background-1);
+
+		.seventv-sm-appinfo {
+			span {
+				font-size: .95rem;
+
+				&:not(:last-child) {
+					margin-right: $space-s;
+				}
 			}
 		}
 	}

--- a/src/Style/Components/Settings.scss
+++ b/src/Style/Components/Settings.scss
@@ -1,6 +1,11 @@
 $borderRadius: 8px;
-$space-s: 10px;
-$space-m: 25px;
+
+$space-xs: 5px;
+$space-sm: 10px;
+$space-md: 18px;
+$space-lg: 25px;
+
+$select-inactive-color: #767676;
 
 .seventv-settings-menu {
 	width: 80vw;
@@ -24,7 +29,7 @@ $space-m: 25px;
 		justify-content: space-between;
 		align-items: center;
 		height: 5rem;
-		padding: $space-s $space-m;
+		padding: $space-sm $space-lg;
 		background-color: var(--seventv-color-background-1);
 
 		.seventv-sm-header-left {
@@ -34,7 +39,7 @@ $space-m: 25px;
 
 			img {
 				height: 100%;
-				margin-right: $space-s;
+				margin-right: $space-sm;
 			}
 
 			.seventv-sm-title {
@@ -48,11 +53,11 @@ $space-m: 25px;
 			.seventv-sm-socials {
 				display: flex;
 				align-items: center;
-				padding: 0px $space-s;
-				margin-right: $space-m;
+				padding: 0px $space-sm;
+				margin-right: $space-lg;
 
 				.seventv-sm-cta {
-					margin-right: $space-s;
+					margin-right: $space-sm;
 				}
 
 				.seventv-sm-social-list {
@@ -98,7 +103,7 @@ $space-m: 25px;
 		justify-content: end;
 		align-items: center;
 		height: 3rem;
-		padding: $space-s $space-m;
+		padding: $space-sm $space-lg;
 		background-color: var(--seventv-color-background-1);
 
 		.seventv-sm-appinfo {
@@ -106,8 +111,40 @@ $space-m: 25px;
 				font-size: .95rem;
 
 				&:not(:last-child) {
-					margin-right: $space-s;
+					margin-right: $space-sm;
 				}
+			}
+		}
+	}
+
+	.seventv-sm-options {
+		.seventv-sm-option-select {
+			margin-left: 15px;
+
+			.seventv-sm-select-label {
+				margin-bottom: $space-xs;
+			}
+
+			.MuiMenuItem-root:hover {
+				background-color: var(--seventv-color-background-0);
+			}
+
+			.Mui-focused {
+				fieldset {
+					border-color: var(--seventv-primary-color);
+				}
+
+				svg {
+					fill: var(--seventv-primary-color);
+				}
+			}
+
+			fieldset {
+				border-color: $select-inactive-color;
+			}
+
+			svg {
+				fill: $select-inactive-color;
 			}
 		}
 	}


### PR DESCRIPTION
Improves the style and UX of the settings modal.

- Easier to tell which helper text belongs to which input
- Sidebar converted to header to reduce unnecessary empty space
- Converted select input from radio group to dropdown to reduce space and improve UX
- Moved version info to footer
- Fixed vertical overflow issue