### PR TITLE
Return 403 forbidden if the user is not an editor (instead of 404).

### DIFF
--- a/apps/api/src/http/v3/gql/mutations/emote_sets/mod.rs
+++ b/apps/api/src/http/v3/gql/mutations/emote_sets/mod.rs
@@ -108,7 +108,9 @@ impl EmoteSetsMutation {
 				})
 				.await
 				.map_err(|()| ApiError::internal_server_error(ApiErrorCode::LoadError, "failed to load editor"))?
-				.ok_or_else(|| ApiError::not_found(ApiErrorCode::LoadError, "you are not an editor for this user"))?;
+				.ok_or_else(|| {
+					ApiError::forbidden(ApiErrorCode::LackingPrivileges, "you are not an editor for this user")
+				})?;
 
 			if editor.state != UserEditorState::Accepted
 				|| !editor.permissions.has_emote_set(EditorEmoteSetPermission::Create)


### PR DESCRIPTION
If the user isn’t an editor, it currently returns 404 Not Found, making it very hard for 3rd party apps to detect permission errors. The only way is to match the error message (which can change).

## Proposed changes

This makes the error consistent with other errors in the same file and in the old API.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
