### PR TITLE
Lot of website stuff

### DIFF
--- a/apps/website/src/components/drop-down.svelte
+++ b/apps/website/src/components/drop-down.svelte
@@ -81,7 +81,7 @@
 		position: absolute;
 		top: 100%;
 		margin: 0;
-		margin-top: 0.25rem;
+		margin-top: 0.7rem;
 		padding: 0;
 		border: var(--border-active) 1px solid;
 		border-radius: 0.5rem;

--- a/apps/website/src/components/emote-preview.svelte
+++ b/apps/website/src/components/emote-preview.svelte
@@ -130,7 +130,7 @@
 		justify-content: center;
 
 		border: 1px solid transparent;
-		border-radius: 0.25rem;
+		border-radius: 0.5rem;
 		cursor: pointer;
 		user-select: none;
 

--- a/apps/website/src/components/emote-set-preview.svelte
+++ b/apps/website/src/components/emote-set-preview.svelte
@@ -82,7 +82,7 @@
 
 		padding: 1rem;
 		border: 1px solid transparent;
-		border-radius: 0.25rem;
+		border-radius: 0.75rem;
 		cursor: pointer;
 
 		border-color: var(--highlight);

--- a/apps/website/src/components/emote-set-preview.svelte
+++ b/apps/website/src/components/emote-set-preview.svelte
@@ -132,10 +132,10 @@
 			width: 100%;
 			height: 100%;
 
-			background-color: var(--bg-light);
+			background-color: var(--bg-dark);
 
 			&::-webkit-progress-bar {
-				background-color: var(--bg-light);
+				background-color: var(--bg-dark);
 			}
 
 			&::-moz-progress-bar {

--- a/apps/website/src/components/events/emote-set-event.svelte
+++ b/apps/website/src/components/events/emote-set-event.svelte
@@ -130,7 +130,10 @@
 		justify-content: start;
 		align-items: center;
 		row-gap: 0.5rem;
-		margin: 1rem 0;
+
+		padding: 1rem;
+		background-color: var(--bg-medium);
+		border-radius: 0.5rem;
 
 		font-size: 0.75rem;
 		font-weight: 500;

--- a/apps/website/src/components/events/user-event.svelte
+++ b/apps/website/src/components/events/user-event.svelte
@@ -97,7 +97,10 @@
 		justify-content: start;
 		align-items: center;
 		row-gap: 0.5rem;
-		margin: 1rem 0;
+
+		padding: 1rem;
+		background-color: var(--bg-medium);
+		border-radius: 0.5rem;
 
 		font-size: 0.75rem;
 		font-weight: 500;

--- a/apps/website/src/components/nav/global-search.svelte
+++ b/apps/website/src/components/nav/global-search.svelte
@@ -224,6 +224,14 @@
 					{#if results.emotes.items}
 						<span class="label">Emotes</span>
 					{/if}
+					{#if query.length !== 0}
+						<Button href="/emotes?q={query}" class="item">
+							{#snippet icon()}
+								<MagnifyingGlass />
+								{query}
+							{/snippet}
+						</Button>
+					{/if}
 					{#each results.emotes.items as result}
 						<Button href="/emotes/{result.id}" class="item">
 							{#snippet icon()}

--- a/apps/website/src/components/nav/global-search.svelte
+++ b/apps/website/src/components/nav/global-search.svelte
@@ -4,7 +4,7 @@
 	import { t } from "svelte-i18n";
 	import { gqlClient } from "$/lib/gql";
 	import { graphql } from "$/gql";
-	import type { SearchResultAll, User } from "$/gql/graphql";
+	import { SortBy, type SearchResultAll, type User } from "$/gql/graphql";
 	import Spinner from "../spinner.svelte";
 	import ResponsiveImage from "../responsive-image.svelte";
 	import ChannelPreview from "../channel-preview.svelte";
@@ -12,6 +12,7 @@
 	import Flags, { emoteToFlags } from "../flags.svelte";
 	import { defaultEmoteSet } from "$/lib/defaultEmoteSet";
 	import { editableEmoteSets } from "$/lib/emoteSets";
+	import { queryEmotes } from "$/lib/emoteQuery";
 
 	let query = $state("");
 
@@ -28,7 +29,7 @@
 
 			return {
 				users: { items: [...users.values()], totalCount: users.size, pageCount: 1 },
-				emotes: { items: [], totalCount: 0, pageCount: 0 },
+				emotes: await queryEmotes(null, [], SortBy.TopDaily, null, 1, 5),
 			};
 		}
 

--- a/apps/website/src/components/settings/editors.svelte
+++ b/apps/website/src/components/settings/editors.svelte
@@ -679,7 +679,6 @@
 	}
 
 	.scroll {
-		overflow: auto;
 		scrollbar-gutter: stable;
 	}
 

--- a/apps/website/src/routes/emote-sets/[id]/+page.svelte
+++ b/apps/website/src/routes/emote-sets/[id]/+page.svelte
@@ -400,11 +400,12 @@
 			display: flex;
 			align-items: center;
 			gap: 0.75rem;
-
+			
 			font-size: 0.875rem;
 			font-weight: 500;
-
+			
 			progress {
+				height: 0.875rem;
 				flex-grow: 1;
 			}
 		}

--- a/apps/website/src/routes/users/[id]/+layout.svelte
+++ b/apps/website/src/routes/users/[id]/+layout.svelte
@@ -78,20 +78,42 @@
 
 {#snippet desktopMenu()}
 	<nav class="link-list hide-on-mobile">
+		<TabLink title={$t("pages.user.active_emotes")} href="/users/{data.id}" big>
+			<Lightning />
+			{#snippet active()}
+				<Lightning weight="fill" />
+			{/snippet}
+		</TabLink>
+		<TabLink title={$t("pages.user.uploaded_emotes")} href="/users/{data.id}/uploaded" big>
+			<Upload />
+			{#snippet active()}
+				<Upload weight="fill" />
+			{/snippet}
+		</TabLink>
+		<TabLink
+			title={$t("common.emote_sets", { values: { count: 2 } })}
+			href="/users/{data.id}/emote-sets"
+			big
+		>
+			<FolderSimple />
+			{#snippet active()}
+				<FolderSimple weight="fill" />
+			{/snippet}
+		</TabLink>
+		<TabLink title={$t("common.activity")} href="/users/{data.id}/activity" big>
+			<Pulse />
+			{#snippet active()}
+				<Pulse weight="fill" />
+			{/snippet}
+		</TabLink>
+		<hr />
+		<TabLink title={$t("common.cosmetics")} href="/users/{data.id}/cosmetics" big>
+			<PaintBrush />
+			{#snippet active()}
+				<PaintBrush weight="fill" />
+			{/snippet}
+		</TabLink>
 		{#await data.streamed.userRequest.value}
-			<Button big onclick={() => (connectionsExpanded = !connectionsExpanded)}>
-				{#snippet icon()}
-					<Link />
-				{/snippet}
-				{$t("common.connections")}
-				{#snippet iconRight()}
-					{#if connectionsExpanded}
-						<CaretDown style="margin-left: auto" />
-					{:else}
-						<CaretRight style="margin-left: auto" />
-					{/if}
-				{/snippet}
-			</Button>
 			<Button big onclick={() => (editorsExpanded = !editorsExpanded)}>
 				{#snippet icon()}
 					<UserCircle />
@@ -105,8 +127,6 @@
 					{/if}
 				{/snippet}
 			</Button>
-			<hr />
-		{:then user}
 			<Button big onclick={() => (connectionsExpanded = !connectionsExpanded)}>
 				{#snippet icon()}
 					<Link />
@@ -120,19 +140,7 @@
 					{/if}
 				{/snippet}
 			</Button>
-			{#if connectionsExpanded}
-				<div class="expanded">
-					<Connections {user} />
-					{#if isMe}
-						<Button href="/settings/account">
-							{#snippet icon()}
-								<Gear />
-							{/snippet}
-							Manage connections
-						</Button>
-					{/if}
-				</div>
-			{/if}
+		{:then user}
 			<Button big onclick={() => (editorsExpanded = !editorsExpanded)}>
 				{#snippet icon()}
 					<UserCircle />
@@ -165,43 +173,33 @@
 					{/await}
 				</div>
 			{/if}
-			<hr />
+			<Button big onclick={() => (connectionsExpanded = !connectionsExpanded)}>
+				{#snippet icon()}
+					<Link />
+				{/snippet}
+				{$t("common.connections")}
+				{#snippet iconRight()}
+					{#if connectionsExpanded}
+						<CaretDown style="margin-left: auto" />
+					{:else}
+						<CaretRight style="margin-left: auto" />
+					{/if}
+				{/snippet}
+			</Button>
+			{#if connectionsExpanded}
+				<div class="expanded">
+					<Connections {user} />
+					{#if isMe}
+						<Button href="/settings/account">
+							{#snippet icon()}
+								<Gear />
+							{/snippet}
+							Manage connections
+						</Button>
+					{/if}
+				</div>
+			{/if}
 		{/await}
-		<TabLink title={$t("pages.user.active_emotes")} href="/users/{data.id}" big>
-			<Lightning />
-			{#snippet active()}
-				<Lightning weight="fill" />
-			{/snippet}
-		</TabLink>
-		<TabLink title={$t("pages.user.uploaded_emotes")} href="/users/{data.id}/uploaded" big>
-			<Upload />
-			{#snippet active()}
-				<Upload weight="fill" />
-			{/snippet}
-		</TabLink>
-		<TabLink
-			title={$t("common.emote_sets", { values: { count: 2 } })}
-			href="/users/{data.id}/emote-sets"
-			big
-		>
-			<FolderSimple />
-			{#snippet active()}
-				<FolderSimple weight="fill" />
-			{/snippet}
-		</TabLink>
-		<hr />
-		<TabLink title={$t("common.cosmetics")} href="/users/{data.id}/cosmetics" big>
-			<PaintBrush />
-			{#snippet active()}
-				<PaintBrush weight="fill" />
-			{/snippet}
-		</TabLink>
-		<TabLink title={$t("common.activity")} href="/users/{data.id}/activity" big>
-			<Pulse />
-			{#snippet active()}
-				<Pulse weight="fill" />
-			{/snippet}
-		</TabLink>
 	</nav>
 {/snippet}
 

--- a/apps/website/src/routes/users/[id]/+page.svelte
+++ b/apps/website/src/routes/users/[id]/+page.svelte
@@ -8,6 +8,7 @@
 	import { emotesLayout } from "$/lib/layout";
 	import { defaultEmoteSet } from "$/lib/defaultEmoteSet";
 	import ActiveEmoteSetButton from "$/components/users/active-emote-set-button.svelte";
+	import { t } from "svelte-i18n";
 
 	let { data }: { data: PageData } = $props();
 
@@ -166,6 +167,14 @@
 	}
 </script>
 
+<svelte:head>
+	<title>Active Emotes - {$t("page_titles.suffix")}</title>
+</svelte:head>
+
+<div class="header-container">
+	<h2>Active Emotes</h2>
+</div>
+
 <div class="buttons">
 	<ActiveEmoteSetButton bind:userData={data.streamed.userRequest.value} />
 	<div class="layout-buttons">
@@ -177,6 +186,19 @@
 {/key}
 
 <style lang="scss">
+	.header-container {
+		display: flex;
+		justify-content: space-between;
+		height: 40px;
+		
+		h2 {
+			font-family: "AKONY";
+			font-size: 1.5rem;
+			font-weight: 700;
+			margin: auto 0;
+		}
+	}
+
 	.buttons {
 		display: flex;
 		gap: 0.5rem;

--- a/apps/website/src/routes/users/[id]/activity/+page.svelte
+++ b/apps/website/src/routes/users/[id]/activity/+page.svelte
@@ -6,6 +6,7 @@
 	import UserEventComponent from "$/components/events/user-event.svelte";
 	import EmoteSetEventComponent from "$/components/events/emote-set-event.svelte";
 	import type { AnyEvent } from "$/gql/graphql";
+	import { t } from "svelte-i18n";
 
 	let { data }: { data: PageData } = $props();
 
@@ -292,35 +293,59 @@
 	let events = $derived(loadEvents(data.id, page));
 </script>
 
-<div class="events">
-	{#await events}
-		<div class="spinner-wrapper">
-			<Spinner />
-		</div>
-	{:then events}
-		{#each events as event, index}
-			{#if event.__typename === "UserEvent"}
-				<UserEventComponent {event} />
-			{:else if event.__typename === "EmoteSetEvent"}
-				<EmoteSetEventComponent {event} />
-			{/if}
-			{#if index !== events.length - 1}
-				<hr />
-			{/if}
-		{/each}
-	{/await}
+<svelte:head>
+	<title>Activity - {$t("page_titles.suffix")}</title>
+</svelte:head>
+
+<div class="layout">
+	<div class="header-container">
+		<h2>Activity</h2>
+	</div>
+	<div class="events">
+		{#await events}
+			<div class="spinner-wrapper">
+				<Spinner />
+			</div>
+		{:then events}
+			{#each events as event, index}
+				{#if event.__typename === "UserEvent"}
+					<UserEventComponent {event} />
+				{:else if event.__typename === "EmoteSetEvent"}
+					<EmoteSetEventComponent {event} />
+				{/if}
+				{#if index !== events.length - 1}
+					<hr />
+				{/if}
+			{/each}
+		{/await}
+	</div>
 </div>
 
 <style lang="scss">
+	.header-container {
+		display: flex;
+		justify-content: space-between;
+		height: 40px;
+		
+		h2 {
+			font-family: "AKONY";
+			font-size: 1.5rem;
+			font-weight: 700;
+			margin: auto 0;
+		}
+	}
+
 	.spinner-wrapper {
 		text-align: center;
+	}
+
+	.layout {
+		overflow: auto;
+		scrollbar-gutter: stable;
 	}
 
 	.events {
 		display: flex;
 		flex-direction: column;
-
-		overflow: auto;
-		scrollbar-gutter: stable;
 	}
 </style>

--- a/apps/website/src/routes/users/[id]/activity/+page.svelte
+++ b/apps/website/src/routes/users/[id]/activity/+page.svelte
@@ -307,14 +307,11 @@
 				<Spinner />
 			</div>
 		{:then events}
-			{#each events as event, index}
+			{#each events as event}
 				{#if event.__typename === "UserEvent"}
 					<UserEventComponent {event} />
 				{:else if event.__typename === "EmoteSetEvent"}
 					<EmoteSetEventComponent {event} />
-				{/if}
-				{#if index !== events.length - 1}
-					<hr />
 				{/if}
 			{/each}
 		{/await}
@@ -347,5 +344,7 @@
 	.events {
 		display: flex;
 		flex-direction: column;
+		gap: 1rem;
+		margin-top: 0.75rem;
 	}
 </style>

--- a/apps/website/src/routes/users/[id]/cosmetics/+page.svelte
+++ b/apps/website/src/routes/users/[id]/cosmetics/+page.svelte
@@ -340,6 +340,9 @@
 				.map((p) => p.paint.id),
 		)}
 		<div class="layout">
+			<div class="header-container">
+				<h2>Cosmetics</h2>
+			</div>
 			<section>
 				<div class="header">
 					<h1>
@@ -475,6 +478,19 @@
 {/await}
 
 <style lang="scss">
+	.header-container {
+		display: flex;
+		justify-content: space-between;
+		height: 40px;
+		
+		h2 {
+			font-family: "AKONY";
+			font-size: 1.5rem;
+			font-weight: 700;
+			margin: auto 0;
+		}
+	}
+
 	.spinner-container {
 		display: flex;
 		justify-content: center;

--- a/apps/website/src/routes/users/[id]/editors/+page.svelte
+++ b/apps/website/src/routes/users/[id]/editors/+page.svelte
@@ -4,6 +4,7 @@
 	import { UserEditorState } from "$/gql/graphql";
 	import { user } from "$/lib/auth";
 	import type { PageData } from "./$types";
+	import { t } from "svelte-i18n";
 
 	let { data }: { data: PageData } = $props();
 
@@ -23,6 +24,14 @@
 	);
 </script>
 
+<svelte:head>
+	<title>Editors - {$t("page_titles.suffix")}</title>
+</svelte:head>
+
+<div class="header-container">
+	<h2>Editors</h2>
+</div>
+
 {#await canManageEditors}
 	<Spinner />
 {:then canManageEditors}
@@ -38,6 +47,19 @@
 {/await}
 
 <style lang="scss">
+	.header-container {
+		display: flex;
+		justify-content: space-between;
+		height: 40px;
+		
+		h2 {
+			font-family: "AKONY";
+			font-size: 1.5rem;
+			font-weight: 700;
+			margin: auto 0;
+		}
+	}
+
 	.width-wrapper {
 		margin-inline: auto;
 		width: 100%;

--- a/apps/website/src/routes/users/[id]/emote-sets/+page.svelte
+++ b/apps/website/src/routes/users/[id]/emote-sets/+page.svelte
@@ -9,11 +9,20 @@
 	import { user } from "$/lib/auth";
 	import { UserEditorState } from "$/gql/graphql";
 	import ActiveEmoteSetButton from "$/components/users/active-emote-set-button.svelte";
+	import { t } from "svelte-i18n";
 
 	let { data }: { data: PageData } = $props();
 
 	let createEmoteSetDialog: DialogMode = $state("hidden");
 </script>
+
+<svelte:head>
+	<title>Emote Sets - {$t("page_titles.suffix")}</title>
+</svelte:head>
+
+<div class="header-container">
+	<h2>Emote Sets</h2>
+</div>
 
 <div class="buttons">
 	<CreateEmoteSetDialog ownerId={data.id} bind:mode={createEmoteSetDialog} />
@@ -49,6 +58,19 @@
 {/await}
 
 <style lang="scss">
+	.header-container {
+		display: flex;
+		justify-content: space-between;
+		height: 40px;
+		
+		h2 {
+			font-family: "AKONY";
+			font-size: 1.5rem;
+			font-weight: 700;
+			margin: auto 0;
+		}
+	}
+
 	.buttons {
 		display: flex;
 		gap: 0.5rem;

--- a/apps/website/src/routes/users/[id]/uploaded/+page.svelte
+++ b/apps/website/src/routes/users/[id]/uploaded/+page.svelte
@@ -7,8 +7,11 @@
 	import LayoutButtons from "$/components/emotes/layout-buttons.svelte";
 	import { defaultEmoteSet } from "$/lib/defaultEmoteSet";
 	import { emotesLayout } from "$/lib/layout";
-	import ActiveEmoteSetButton from "$/components/users/active-emote-set-button.svelte";
 	import { t } from "svelte-i18n";
+	import Button from "$/components/input/button.svelte";
+	import { uploadDialogMode } from "$/lib/layout";
+	import { PlusSquare } from "phosphor-svelte";
+
 
 	let { data }: { data: PageData } = $props();
 
@@ -155,7 +158,12 @@
 </div>
 
 <div class="buttons">
-	<ActiveEmoteSetButton bind:userData={data.streamed.userRequest.value} />
+	<Button secondary onclick={() => ($uploadDialogMode = "shown")}>
+		{#snippet icon()}
+			<PlusSquare />
+		{/snippet}
+		{$t("dialogs.upload.upload")}
+	</Button>
 	<div class="layout-buttons">
 		<LayoutButtons bind:value={$emotesLayout} />
 	</div>

--- a/apps/website/src/routes/users/[id]/uploaded/+page.svelte
+++ b/apps/website/src/routes/users/[id]/uploaded/+page.svelte
@@ -8,6 +8,7 @@
 	import { defaultEmoteSet } from "$/lib/defaultEmoteSet";
 	import { emotesLayout } from "$/lib/layout";
 	import ActiveEmoteSetButton from "$/components/users/active-emote-set-button.svelte";
+	import { t } from "svelte-i18n";
 
 	let { data }: { data: PageData } = $props();
 
@@ -145,6 +146,14 @@
 	}
 </script>
 
+<svelte:head>
+	<title>Uploaded Emotes - {$t("page_titles.suffix")}</title>
+</svelte:head>
+
+<div class="header-container">
+	<h2>Uploaded Emotes</h2>
+</div>
+
 <div class="buttons">
 	<ActiveEmoteSetButton bind:userData={data.streamed.userRequest.value} />
 	<div class="layout-buttons">
@@ -156,6 +165,19 @@
 {/key}
 
 <style lang="scss">
+	.header-container {
+		display: flex;
+		justify-content: space-between;
+		height: 40px;
+		
+		h2 {
+			font-family: "AKONY";
+			font-size: 1.5rem;
+			font-weight: 700;
+			margin: auto 0;
+		}
+	}
+
 	.buttons {
 		display: flex;
 		gap: 0.5rem;


### PR DESCRIPTION
## Proposed changes

- Added titles for user pages:
![image](https://github.com/user-attachments/assets/c55da990-a716-4bf8-8c57-cd7ce722d063)
- Changed the "active emote set" button to the "upload emote" button on the "Uploaded emotes" page
![image](https://github.com/user-attachments/assets/8a263956-aeb3-4f3f-b5a9-e1f67fbbeae0)
- Made the user dropdown align with the global navbar
![image](https://github.com/user-attachments/assets/f64f71ad-e5ae-486e-88c8-8da93ab89aa3)
- Improved the visuals for progress bars by giving them a darker background
![image](https://github.com/user-attachments/assets/652c2888-e3a1-4851-a4b8-9772ec3132aa)
  Also by making the one in the emote set page taller
![image](https://github.com/user-attachments/assets/cacaa62b-833a-41e0-a58f-a25b7d957b43)
- Updated the activity page to be more consistent with the rest of the website's design **WARNING: BIG CHANGE!!**
![image](https://github.com/user-attachments/assets/ce392497-d849-45fd-94a5-4b33cef832e2)
  This is a big change, but it's in 1 commit. If you don't like it you can always undo this commit, but in my opinion it fits better with the rest of the pages.
- Added 5 trending emotes for default search results when there is no query in the global search
![image](https://github.com/user-attachments/assets/f883da0c-3386-4ed2-86fe-f0f4d1603e8a)
- Added a button to instantly redirect to the emote page with the current query from global search
![image](https://github.com/user-attachments/assets/0d9b692e-533d-418e-8d2c-4249f4656a13)
- Fix this layout issue in editors page
![image](https://github.com/user-attachments/assets/c96393b1-196b-4ca2-b55d-b8fb0370cd7c)
![image](https://github.com/user-attachments/assets/3515e753-13be-4901-bf28-1a5975e72550)
- Rearrange tabs in sidebar (courtesy of bubu)
![image](https://github.com/user-attachments/assets/d1b7ca82-4a35-4a09-b25c-277d133e661b)
- Increase padding for emote and emote set elements
![image](https://github.com/user-attachments/assets/e38f7f6c-bba9-4f2b-a808-f7d477623ccb)
![image](https://github.com/user-attachments/assets/4ff63204-1c17-4d67-b40a-6b2036af7d3d)

## Types of changes

What types of changes does your code introduce to 7TV?

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
