### PR TITLE
fix(website): permission check admin nav button

### DIFF
--- a/apps/website/src/components/nav/menu.svelte
+++ b/apps/website/src/components/nav/menu.svelte
@@ -98,10 +98,12 @@
 				<Star />
 				{$t("pages.store.title")}
 			</MenuButton>
-			<MenuButton href="/admin" style="color: var(--staff)">
-				<Wrench />
-				Admin
-			</MenuButton>
+			{#if $user?.permissions.user.manageAny}
+				<MenuButton href="/admin" style="color: var(--staff)">
+					<Wrench />
+					{$t("pages.admin.title")}
+				</MenuButton>
+			{/if}
 		</div>
 		{#if $user}
 			<div class="link-list">


### PR DESCRIPTION
## Proposed changes

Currently the admin nav button is shown for everyone on the mobile nav dropdown.
Added a permission check, and replaced the hard coded string with i18n.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged
