### PR TITLE
fix(website): `max-height` in search results

### DIFF
--- a/apps/website/src/components/nav/global-search.svelte
+++ b/apps/website/src/components/nav/global-search.svelte
@@ -266,11 +266,14 @@
 
 		background-color: var(--bg-light);
 
+		max-height: 50vh;
+
 		border: 1px solid var(--border-active);
 		border-radius: 0.5rem;
 
 		display: none;
-		overflow: hidden;
+		overflow-x: hidden;
+		overflow-y: auto;
 
 		flex-direction: column;
 


### PR DESCRIPTION
## Proposed changes

Adds `max-height` and ability to scroll to the search results. Without it search results can get off screen in some scenarios.
| Before  | After |
| ------------- | ------------- |
|![2024-12-29-164743_hyprshot](https://github.com/user-attachments/assets/266a77cf-4ab2-4f82-8bd9-5d34fdbc3188) |![2024-12-29-165041_hyprshot](https://github.com/user-attachments/assets/1287b603-99bd-40b2-8168-96905410ea84) |

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged
