### PR TITLE
Feature: Add paint sorting dropdown to 7tv website UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 local/
 .env
 .envrc
+.vs/

--- a/apps/website/src/routes/users/[id]/cosmetics/+page.svelte
+++ b/apps/website/src/routes/users/[id]/cosmetics/+page.svelte
@@ -157,6 +157,7 @@
 			);
 
 		const paints: { [key: string]: { paint: Paint; sourceKey?: string; sourceName?: string } } = {};
+		const paintSortings: Option[] = [];
 		const paintFilters: Option[] = [];
 
 		for (const entitlement of inventory.paints.filter((p) => p.to.paint)) {
@@ -169,6 +170,18 @@
 					sourceKey: roleId,
 					sourceName: roleName,
 				};
+
+				if (!paintSortings.some((s) => s.value === 'sort-asc')) {
+					paintSortings.push({
+						label: 'Sort Asc. (A-Z)',
+						value: 'sort-asc',
+					});
+				} else if (!paintSortings.some((s) => s.value === 'sort-desc')) {
+					paintFilters.push({
+						label: 'Sort Desc. (Z-A)',
+						value: 'sort-desc',
+					});
+				}
 
 				if (!paintFilters.some((f) => f.value === roleId)) {
 					paintFilters.push({
@@ -235,6 +248,7 @@
 	let editingEnabled = $derived($user?.id === data.id || $user?.permissions.user.manageAny);
 
 	let paintQuery = $state("");
+	let paintSorting = $state<string>("");
 	let paintFilter = $state<string>("");
 	let paintsLayout = $state<Layout>("big-grid");
 
@@ -337,6 +351,13 @@
 						(!paintFilter || p.sourceKey === paintFilter) &&
 						(!paintQuery || p.paint.name.toLowerCase().includes(paintQuery.trim().toLowerCase())),
 				)
+				.sort((a, b) => {
+					if (paintSorting === 'sort-asc') {
+						return a.paint.name.toLowerCase() < b.paint.name.toLowerCase() ? -1 : (a.paint.name.toLowerCase() > b.paint.name.toLowerCase() ? 1 : 0);
+					} else if (paintSorting === 'sort-desc') {
+						return b.paint.name.toLowerCase() < a.paint.name.toLowerCase() ? -1 : (b.paint.name.toLowerCase() > a.paint.name.toLowerCase() ? 1 : 0);
+					}
+				})
 				.map((p) => p.paint.id),
 		)}
 		<div class="layout">
@@ -403,6 +424,12 @@
 						{/if}
 					</h1>
 					<div class="buttons">
+						{#if inventory.paintSortings.length > 0}
+							<Select
+								bind:selected={paintSorting}
+								options={[{ label: "Default", value: "" }, ...inventory.paintSortings]}
+							/>
+						{/if}
 						{#if inventory.paintFilters.length > 0}
 							<Select
 								bind:selected={paintFilter}


### PR DESCRIPTION
## Proposed changes

Adds a drop down to sort paints alphabetically ASC or DESC. 

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged

## Personal Notes
It's been a minute since I've worked in js and I've never used svelte components so bear with me on these changes. But it should be a rather simple 'feature' (if you can even call it that lol). So shouldn't require TOO much, you know? This was just a feature request by NotClusta and the dev team said they were too busy to handle small stuff like this. Thanks!
