### PR TITLE
feat(website): Minor UI/UX improvement of the global search

### DIFF
--- a/apps/website/src/components/nav/global-search.svelte
+++ b/apps/website/src/components/nav/global-search.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { MagnifyingGlass } from "phosphor-svelte";
+	import { ArrowSquareOut, MagnifyingGlass } from "phosphor-svelte";
 	import TextInput from "../input/text-input.svelte";
 	import { t } from "svelte-i18n";
 	import { gqlClient } from "$/lib/gql";
@@ -198,13 +198,8 @@
 
 	function handleInputKeyPress(event: KeyboardEvent) {
 		if (event.key === "Enter" && query.trim() != "") {
-			openEmotesPage();
+			goto(`/emotes?q=${query}`);
 		}
-	}
-
-	function openEmotesPage() {
-		goto(`/emotes?q=${query}`);
-		query = "";
 	}
 </script>
 
@@ -230,7 +225,12 @@
 			{#if results && (results.users.items.length > 0 || results.emotes.items.length > 0)}
 				<div class="results">
 					{#if results.emotes.items}
-						<span class="label">Emotes</span>
+						<div class="container-flex">
+							<span class="label">Emotes</span>
+							<span class="open-button">
+								<Button href="/emotes?q={query}"><ArrowSquareOut /></Button>
+							</span>
+						</div>
 					{/if}
 					{#each results.emotes.items as result}
 						<Button href="/emotes/{result.id}" class="item">
@@ -264,6 +264,18 @@
 <style lang="scss">
 	:global(label.input):focus-within > .results {
 		display: flex;
+	}
+
+	.open-button {
+		margin: 0.3rem;
+	}
+
+	.container-flex {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+		flex-wrap: wrap;
 	}
 
 	.results {

--- a/apps/website/src/components/nav/global-search.svelte
+++ b/apps/website/src/components/nav/global-search.svelte
@@ -198,7 +198,7 @@
 
 	function handleInputKeyPress(event: KeyboardEvent) {
 		if (event.key === "Enter" && query.trim() != "") {
-			goto(`/emotes?q=${query}`);
+			goto(`/emotes?q=${query}&updateSearch=true`);
 		}
 	}
 </script>
@@ -228,7 +228,7 @@
 						<div class="container-flex">
 							<span class="label">Emotes</span>
 							<span class="open-button">
-								<Button href="/emotes?q={query}"><ArrowSquareOut /></Button>
+								<Button href="/emotes?q={query}&updateSearch=true"><ArrowSquareOut /></Button>
 							</span>
 						</div>
 					{/if}

--- a/apps/website/src/components/nav/global-search.svelte
+++ b/apps/website/src/components/nav/global-search.svelte
@@ -13,6 +13,7 @@
 	import { defaultEmoteSet } from "$/lib/defaultEmoteSet";
 	import { editableEmoteSets } from "$/lib/emoteSets";
 	import { user } from "$/lib/auth";
+	import { goto } from "$app/navigation";
 
 	let query = $state("");
 
@@ -194,6 +195,17 @@
 			event.stopPropagation();
 		}
 	}
+
+	function handleInputKeyPress(event: KeyboardEvent) {
+		if (event.key === "Enter" && query.trim() != "") {
+			openEmotesPage();
+		}
+	}
+
+	function openEmotesPage() {
+		goto(`/emotes?q=${query}`);
+		query = "";
+	}
 </script>
 
 <svelte:window {onkeydown} />
@@ -201,6 +213,7 @@
 <TextInput
 	placeholder={$t("labels.search")}
 	bind:value={query}
+	onkeypress={handleInputKeyPress}
 	style="flex: 0 1 20rem"
 	big
 	bind:this={input}

--- a/apps/website/src/routes/emotes/(directory)/+layout.svelte
+++ b/apps/website/src/routes/emotes/(directory)/+layout.svelte
@@ -12,7 +12,7 @@
 	import { t } from "svelte-i18n";
 	import { page } from "$app/stores";
 	import { type Page } from "@sveltejs/kit";
-	import { goto } from "$app/navigation";
+	import { goto, invalidate } from "$app/navigation";
 	import type { Snippet } from "svelte";
 
 	let { children }: { children: Snippet } = $props();
@@ -90,7 +90,10 @@
 			url.searchParams.delete("e");
 		}
 
-		goto(url, { replaceState: true, noScroll: true, keepFocus: true });
+		if (url.toString() !== $page.url.toString()) {
+			goto(url, { replaceState: true, noScroll: true, keepFocus: true });
+			invalidate(url.pathname);
+		}
 	});
 
 	function menuMatcher(page: Page, href: string | undefined) {

--- a/apps/website/src/routes/emotes/(directory)/+layout.svelte
+++ b/apps/website/src/routes/emotes/(directory)/+layout.svelte
@@ -48,6 +48,12 @@
 	$effect(() => {
 		let url = new URL($page.url);
 
+		// Needed for update when on the same page
+		if ($page.url.searchParams.get("updateSearch") === "true") {
+			query = $page.url.searchParams.get("q") ?? undefined;
+			url.searchParams.delete("updateSearch");
+		}
+
 		if (query) {
 			url.searchParams.set("q", query);
 		} else {
@@ -90,10 +96,7 @@
 			url.searchParams.delete("e");
 		}
 
-		if (url.toString() !== $page.url.toString()) {
-			goto(url, { replaceState: true, noScroll: true, keepFocus: true });
-			invalidate(url.pathname);
-		}
+		goto(url, { replaceState: true, noScroll: true, keepFocus: true });
 	});
 
 	function menuMatcher(page: Page, href: string | undefined) {

--- a/apps/website/src/routes/emotes/(directory)/+layout.svelte
+++ b/apps/website/src/routes/emotes/(directory)/+layout.svelte
@@ -12,7 +12,7 @@
 	import { t } from "svelte-i18n";
 	import { page } from "$app/stores";
 	import { type Page } from "@sveltejs/kit";
-	import { goto, invalidate } from "$app/navigation";
+	import { goto } from "$app/navigation";
 	import type { Snippet } from "svelte";
 
 	let { children }: { children: Snippet } = $props();


### PR DESCRIPTION
## Proposed changes
This is a very small change to the UI and UX of the global search. I added a small button to open a global search into the full page emote search. This is useful when the emote you are looking for does not appear in the few results of the global search and prevents the need of retyping the search in the emotes page. This navigation is also now bound to the enter key when the global search is focused. 

This has been reported as an issue [here](https://discord.com/channels/817075418054000661/1323105375704322128)

![image](https://github.com/user-attachments/assets/08fac7f7-9a24-4ede-b042-41277ac036aa)

This is my first contribution, so please tell me if anything is wrong.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
(I tried opening the CLA but I get this error)
![image](https://github.com/user-attachments/assets/20e6f64e-4c60-4549-9e57-e4d6105407c7)
- [ ] I have added necessary documentation (if appropriate)
(N/A)
- [ ] Any dependent changes have been merged
(Not sure what this means)