### PR TITLE
fix: static name non animated images

### DIFF
--- a/shared/src/old_types/image.rs
+++ b/shared/src/old_types/image.rs
@@ -103,7 +103,7 @@ impl From<&Image> for ImageFile {
 		let (name, ext) = name.split_once('.').unwrap_or((&name, ""));
 
 		Self {
-			static_name: format!("{}_static.{}", name, ext),
+			static_name: format!("{}{}.{}", name, if value.frame_count > 1 { "_static" } else { "" }, ext),
 			name: format!("{}.{}", name, ext),
 			width: value.width as u32,
 			height: value.height as u32,


### PR DESCRIPTION
## Proposed changes

Images that are not animated do not need the `_static` suffix. This fixes the problem where static images have a invalid `static_name` CDN URL.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
