### PR TITLE
fix: first frame timing problem

### DIFF
--- a/apps/image-processor/src/worker/process/blocking.rs
+++ b/apps/image-processor/src/worker/process/blocking.rs
@@ -323,6 +323,9 @@ impl<'a> BlockingTask<'a> {
 		let idx = self.frame_idx;
 		self.frame_idx += 1;
 
+		// Convert from the decode timescale into ms.
+		frame.duration_ts = (frame.duration_ts as f64 * 1000.0 / self.decoder_info.timescale as f64).round() as u64;
+
 		let variants = if idx == self.static_frame_idx {
 			let variants = self.resizer.resize(frame)?;
 
@@ -337,9 +340,6 @@ impl<'a> BlockingTask<'a> {
 		} else {
 			None
 		};
-
-		// Convert from the decode timescale into ms.
-		frame.duration_ts = (frame.duration_ts as f64 * 1000.0 / self.decoder_info.timescale as f64).round() as u64;
 
 		if let Some(config) = self.frame_configs.get(idx).ok_or(JobError::Internal(""))? {
 			match config {


### PR DESCRIPTION
## Proposed changes

Fix timing issues on the first frame of added animated emotes, which was especially prominent on .mp4 file

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc (CLA is unavailable)
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged
