### PR TITLE
Added a button to copy emote images directly

### DIFF
--- a/apps/website/pnpm-lock.yaml
+++ b/apps/website/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      svelte-eslint-parser:
-        specifier: ^0.43.0
-        version: 0.43.0(svelte@5.11.2)
     devDependencies:
       '@eslint/js':
         specifier: ^9.16.0
@@ -96,6 +92,9 @@ importers:
       svelte-check:
         specifier: ^4.1.1
         version: 4.1.1(svelte@5.11.2)(typescript@5.7.2)
+      svelte-eslint-parser:
+        specifier: ^0.43.0
+        version: 0.43.0(svelte@5.11.2)
       svelte-fa:
         specifier: ^4.0.3
         version: 4.0.3(svelte@5.11.2)

--- a/apps/website/src/components/emotes/emote-info.svelte
+++ b/apps/website/src/components/emotes/emote-info.svelte
@@ -258,27 +258,30 @@
 				{/if}
 				<a href={undefined} style="display: none" bind:this={downloadElement}>Download</a>
 				<DropDown bind:this={moreMenuDropdown}>
-					<Button secondary hideOnMobile onclick={() => (moreMenuMode = "root")}>
-						{#if $user}
-							{$t("labels.more")}
-						{:else}
-							{$t("labels.actions")}
-						{/if}
+					{#if !data?.imagesPending && formats && formats.length > 1}
+						<Button secondary hideOnMobile onclick={() => (moreMenuMode = "root")}>
+							{#if $user}
+								{$t("labels.more")}
+							{:else}
+								{$t("labels.actions")}
+							{/if}
 
-						{#snippet iconRight()}
-							<CaretDown />
-						{/snippet}
-					</Button>
-					<Button secondary hideOnDesktop onclick={() => (moreMenuMode = "root")}>
-						{#if $user}
-							{$t("labels.more")}
-						{:else}
-							{$t("labels.actions")}
-						{/if}
-						{#snippet iconRight()}
-							<CaretDown />
-						{/snippet}
-					</Button>
+							{#snippet iconRight()}
+								<CaretDown />
+							{/snippet}
+						</Button>
+						<Button secondary hideOnDesktop onclick={() => (moreMenuMode = "root")}>
+							{#if $user}
+								{$t("labels.more")}
+							{:else}
+								{$t("labels.actions")}
+							{/if}
+							{#snippet iconRight()}
+								<CaretDown />
+							{/snippet}
+						</Button>
+					{/if}
+
 					{#snippet dropdown()}
 						<div class="dropdown">
 							{#if moreMenuMode === "root"}

--- a/apps/website/src/components/emotes/emote-info.svelte
+++ b/apps/website/src/components/emotes/emote-info.svelte
@@ -49,7 +49,7 @@
 	let moreMenuDropdown: ReturnType<typeof DropDown>;
 	let moreMenuMode: MoreMenuMode = $state("root");
 	let downloadFormat = $state<string>();
-	let moreMenuAction: MoreMenuAction = "download";
+	let moreMenuAction: MoreMenuAction = $state("download");
 
 	let formats = $derived(
 		data?.images
@@ -258,41 +258,18 @@
 				{/if}
 				<a href={undefined} style="display: none" bind:this={downloadElement}>Download</a>
 				<DropDown bind:this={moreMenuDropdown}>
-					{#if (!$user || data?.deleted) && !data?.imagesPending && formats && formats.length > 1}
-						<Button
-							secondary
-							onclick={() => {
-								moreMenuMode = "format";
-								moreMenuAction = "download";
-							}}
-						>
-							<Download />
-							{$t("labels.download")}
-						</Button>
-						<Button
-							secondary
-							onclick={() => {
-								moreMenuMode = "format";
-								moreMenuAction = "copy";
-							}}
-						>
-							<CopySimple />
-							{$t("labels.copy_link")}
-						</Button>
-					{/if}
-					{#if $user && !data?.deleted}
-						<Button secondary hideOnMobile onclick={() => (moreMenuMode = "root")}>
-							{$t("labels.more")}
-							{#snippet iconRight()}
-								<CaretDown />
-							{/snippet}
-						</Button>
-						<Button secondary hideOnDesktop>
-							{#snippet icon()}
-								<CaretDown />
-							{/snippet}
-						</Button>
-					{/if}
+					<Button secondary hideOnMobile onclick={() => (moreMenuMode = "root")}>
+						{$t("labels.more")}
+						{#snippet iconRight()}
+							<CaretDown />
+						{/snippet}
+					</Button>
+					<Button secondary hideOnDesktop onclick={() => (moreMenuMode = "root")}>
+						{$t("labels.actions")}
+						{#snippet iconRight()}
+							<CaretDown />
+						{/snippet}
+					</Button>
 					{#snippet dropdown()}
 						<div class="dropdown">
 							{#if moreMenuMode === "root"}
@@ -326,7 +303,7 @@
 											moreMenuAction = "copy";
 										}}
 									>
-										<Download />
+										<CopySimple />
 										{$t("labels.copy_link")}
 									</MenuButton>
 								{/if}

--- a/apps/website/src/components/emotes/emote-info.svelte
+++ b/apps/website/src/components/emotes/emote-info.svelte
@@ -259,13 +259,22 @@
 				<a href={undefined} style="display: none" bind:this={downloadElement}>Download</a>
 				<DropDown bind:this={moreMenuDropdown}>
 					<Button secondary hideOnMobile onclick={() => (moreMenuMode = "root")}>
-						{$t("labels.more")}
+						{#if $user}
+							{$t("labels.more")}
+						{:else}
+							{$t("labels.actions")}
+						{/if}
+
 						{#snippet iconRight()}
 							<CaretDown />
 						{/snippet}
 					</Button>
 					<Button secondary hideOnDesktop onclick={() => (moreMenuMode = "root")}>
-						{$t("labels.actions")}
+						{#if $user}
+							{$t("labels.more")}
+						{:else}
+							{$t("labels.actions")}
+						{/if}
 						{#snippet iconRight()}
 							<CaretDown />
 						{/snippet}

--- a/apps/website/src/components/emotes/emote-info.svelte
+++ b/apps/website/src/components/emotes/emote-info.svelte
@@ -142,6 +142,11 @@
 		});
 	}
 
+	function setDialogState(mode: MoreMenuMode, download: boolean = true) {
+		moreMenuMode = mode;
+		moreMenuAction = download ? "download" : "copy";
+	}
+
 	async function copyToClipboard(text: string) {
 		moreMenuDropdown?.close();
 		await navigator.clipboard.writeText(text);
@@ -301,8 +306,7 @@
 									<MenuButton
 										iconRight={caret}
 										onclick={() => {
-											moreMenuMode = "format";
-											moreMenuAction = "download";
+											setDialogState("format", true);
 										}}
 									>
 										<Download />
@@ -311,8 +315,7 @@
 									<MenuButton
 										iconRight={caret}
 										onclick={() => {
-											moreMenuMode = "format";
-											moreMenuAction = "copy";
+											setDialogState("format", false);
 										}}
 									>
 										<CopySimple />

--- a/apps/website/src/locales/en.json
+++ b/apps/website/src/locales/en.json
@@ -108,7 +108,8 @@
 		"accept": "Accept",
 		"deny": "Deny",
 		"enter": "Enter",
-		"copy_link": "Copy Image Link"
+		"copy_link": "Copy Image Link",
+		"actions": "Actions"
 	},
 	"themes": {
 		"system": "System",

--- a/apps/website/src/locales/en.json
+++ b/apps/website/src/locales/en.json
@@ -107,7 +107,8 @@
 		"remove": "Remove",
 		"accept": "Accept",
 		"deny": "Deny",
-		"enter": "Enter"
+		"enter": "Enter",
+		"copy_link": "Copy Image Link"
 	},
 	"themes": {
 		"system": "System",


### PR DESCRIPTION
## Proposed changes

I added a simple button that allows the user to copy the image link of an emote directly. This is a small QoL feature that has been requested by multiple users and that I also personally have felt the need for.
![image](https://github.com/user-attachments/assets/6c79ac48-ba8c-40b4-a600-a0aa8bd1f3bc)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
(I could not sign the CLA)
![image](https://github.com/user-attachments/assets/20e6f64e-4c60-4549-9e57-e4d6105407c7)
- [x] I have added necessary documentation (if appropriate)
(N/A)
- [x] Any dependent changes have been merged
(N/A)
