### PR TITLE
Re-add spaces to authorized chars in Emote sets names

### DIFF
--- a/apps/api/src/http/validators.rs
+++ b/apps/api/src/http/validators.rs
@@ -38,7 +38,7 @@ pub fn check_name(value: impl AsRef<str>) -> bool {
 	static REGEX: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
 
 	REGEX
-		.get_or_init(|| regex::Regex::new(r"^[a-zA-Z0-9_\-():!+|.'?><\p{Emoji_Presentation}*$#]{1,100}$").unwrap())
+		.get_or_init(|| regex::Regex::new(r"^[a-zA-Z0-9_\-():!+|.'?><\p{Emoji_Presentation}*$# ]{1,100}$").unwrap())
 		.is_match(value.as_ref())
 }
 


### PR DESCRIPTION
## Proposed changes

Re-added spaces to authorized chars in Emote sets names.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
(I could not sign the CLA)
![image](https://github.com/user-attachments/assets/20e6f64e-4c60-4549-9e57-e4d6105407c7)
- [x] I have added necessary documentation (if appropriate)
(N/A)
- [x] Any dependent changes have been merged
(N/A)