### PR TITLE
fix: emote count for sets with duplicate emotes

### DIFF
--- a/apps/api/src/http/v4/gql/types/emote_set.rs
+++ b/apps/api/src/http/v4/gql/types/emote_set.rs
@@ -55,6 +55,7 @@ impl EmoteSet {
 			})
 			.cloned()
 			.collect_vec();
+		let total_count = filtered.len() as u64;
 
 		let emotes = global
 			.emote_by_id_loader
@@ -78,8 +79,8 @@ impl EmoteSet {
 				.collect();
 
 			Ok(SearchResult {
-				total_count: emotes.len() as u64,
-				page_count: (emotes.len() as u64 / chunk_size as u64) + 1,
+				total_count,
+				page_count: (total_count / chunk_size as u64) + 1,
 				items,
 			})
 		} else {
@@ -90,7 +91,7 @@ impl EmoteSet {
 				.collect();
 
 			Ok(SearchResult {
-				total_count: emotes.len() as u64,
+				total_count,
 				page_count: 1,
 				items,
 			})


### PR DESCRIPTION
## Proposed changes

This PR fixes the emote count for sets that have the same emote added multiple times under different aliases ([Example](https://7tv.app/emote-sets/01JJ4V3R3SDARWBCMKD4GX1HTX)). This wrong `total_count` value currently also blocks further scrolling on the new frontend on these emote sets.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
(cla currently unavailable)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
