### PR TITLE
fix: inconsisent/missing emote alias validators

### DIFF
--- a/apps/api/src/http/v4/gql/mutations/emote_set/operation.rs
+++ b/apps/api/src/http/v4/gql/mutations/emote_set/operation.rs
@@ -22,7 +22,7 @@ use crate::http::error::{ApiError, ApiErrorCode};
 use crate::http::guards::{PermissionGuard, RateLimitGuard};
 use crate::http::middleware::session::Session;
 use crate::http::v4::gql::types::{Emote, EmoteSet, EmoteSetEmote};
-use crate::http::validators::{EmoteNameValidator, NameValidator, TagsValidator};
+use crate::http::validators::{EmoteAliasValidator, NameValidator, TagsValidator};
 use crate::transactions::{transaction_with_mutex, GeneralMutexKey, TransactionError};
 
 pub struct EmoteSetOperation {
@@ -128,6 +128,7 @@ impl EmoteSetOperation {
 #[derive(async_graphql::InputObject, Clone)]
 pub struct EmoteSetEmoteId {
 	pub emote_id: EmoteId,
+	#[graphql(validator(custom = "EmoteAliasValidator"))]
 	pub alias: Option<String>,
 }
 
@@ -922,7 +923,7 @@ impl EmoteSetOperation {
 		&self,
 		ctx: &Context<'_>,
 		id: EmoteSetEmoteId,
-		#[graphql(validator(custom = "EmoteNameValidator"))] alias: String,
+		#[graphql(validator(custom = "EmoteAliasValidator"))] alias: String,
 	) -> Result<EmoteSetEmote, ApiError> {
 		let global: &Arc<Global> = ctx
 			.data()

--- a/apps/api/src/http/validators.rs
+++ b/apps/api/src/http/validators.rs
@@ -22,6 +22,27 @@ pub fn check_emote_name(value: impl AsRef<str>) -> bool {
 }
 
 #[derive(Debug, Copy, Clone)]
+pub struct EmoteAliasValidator;
+
+impl CustomValidator<String> for EmoteAliasValidator {
+	fn check(&self, value: &String) -> Result<(), async_graphql::InputValueError<String>> {
+		if check_emote_alias(value) {
+			Ok(())
+		} else {
+			Err(async_graphql::InputValueError::custom("invalid emote alias"))
+		}
+	}
+}
+
+pub fn check_emote_alias(value: impl AsRef<str>) -> bool {
+	static REGEX: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+
+	REGEX
+		.get_or_init(|| regex::Regex::new(r"^[^\x00-\x20\u{00A0}\u{180E}\u{2000}-\u{200A}\u{202F}\u{205F}\u{3000}\u{E0000}]{1,100}$").unwrap())
+		.is_match(value.as_ref())
+}
+
+#[derive(Debug, Copy, Clone)]
 pub struct NameValidator;
 
 impl CustomValidator<String> for NameValidator {


### PR DESCRIPTION
## Proposed changes

This PR makes validation of emote aliases consistent across the `addEmote` and `updateEmoteAlias` operations. The new emote alias regex allows any character except common Unicode spaces and a length of up to 100 characters. This continues allowing localized channels to use non-Latin characters in their emote sets while still only allowing Latin characters for actual emote names.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
      (cla currently unavailable)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
