### PR TITLE
feat(api): list Chatterino7 updates on `/v3`

### DIFF
--- a/apps/api/src/config.rs
+++ b/apps/api/src/config.rs
@@ -48,6 +48,9 @@ pub struct Api {
 
 	/// IP Header config
 	pub incoming_request: IncomingRequestConfig,
+
+	/// Chatterino config
+	pub chatterino: ChatterinoConfig,
 }
 
 #[derive(Debug, Clone, smart_default::SmartDefault, serde::Deserialize, serde::Serialize)]
@@ -127,6 +130,18 @@ pub struct PayPalConfig {
 	/// PayPal webhook id
 	#[default("webhook_id".into())]
 	pub webhook_id: String,
+}
+
+#[derive(Debug, Clone, smart_default::SmartDefault, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
+pub struct ChatterinoConfig {
+	/// Current stable version (without the 'v' prefix)
+	#[default("7.5.3".into())]
+	pub stable_version: String,
+
+	/// Current beta version (without the 'v' prefix, [None] if there's no beta version)
+	#[default(None)]
+	pub beta_version: Option<String>,
 }
 
 #[derive(Debug, Clone, smart_default::SmartDefault, serde::Deserialize, serde::Serialize)]

--- a/apps/api/src/http/v3/mod.rs
+++ b/apps/api/src/http/v3/mod.rs
@@ -35,6 +35,7 @@ pub fn docs() -> utoipa::openapi::OpenApi {
 	docs.merge(docs::Docs::openapi());
 	docs.merge(gql::Docs::openapi());
 	docs.merge(rest::types::Docs::openapi());
+	docs.merge(rest::chatterino::Docs::openapi());
 	docs.merge(rest::config::Docs::openapi());
 	docs.merge(rest::auth::Docs::openapi());
 	docs.merge(rest::emotes::Docs::openapi());

--- a/apps/api/src/http/v3/rest/chatterino.rs
+++ b/apps/api/src/http/v3/rest/chatterino.rs
@@ -1,0 +1,140 @@
+use std::str::FromStr;
+use std::sync::{Arc, OnceLock};
+
+use axum::extract::State;
+use axum::routing::get;
+use axum::{Json, Router};
+
+use crate::global::Global;
+use crate::http::error::{ApiError, ApiErrorCode};
+use crate::http::extract::Path;
+
+#[derive(utoipa::OpenApi)]
+#[openapi(paths(get_version_info))]
+pub struct Docs;
+
+pub fn routes() -> Router<Arc<Global>> {
+	Router::new().route("/version/:os/:branch", get(get_version_info))
+}
+
+#[utoipa::path(
+	get,
+	path = "/v3/chatterino/version/{os}/{branch}",
+	tag = "chatterino",
+	responses(
+		(status = 200, description = "Chatterino7 versions", body = ChatterinoVersion, content_type = "application/json"),
+	),
+	params(
+		("os" = String, Path, description = "The name of the operating system (win/macos/linux)"), 
+		("branch" = String, Path, description = "The update branch (stable/beta)"), 
+	)
+)]
+#[tracing::instrument(skip_all)]
+async fn get_version_info(
+	State(global): State<Arc<Global>>,
+	Path((os, branch)): Path<(String, String)>,
+) -> Result<Json<&'static serde_json::Value>, ApiError> {
+	let Ok(os) = os.parse::<Os>() else {
+		return Err(ApiError::not_found(ApiErrorCode::BadRequest, "Unknown OS"));
+	};
+	let Ok(branch) = branch.parse::<Branch>() else {
+		return Err(ApiError::not_found(ApiErrorCode::BadRequest, "Unknown branch"));
+	};
+
+	macro_rules! make_statics {
+		() => {{
+			static VALUE: OnceLock<serde_json::Value> = OnceLock::new();
+			Ok(Json(VALUE.get_or_init(|| os.info_for_version(branch.resolve(&global)))))
+		}};
+	}
+
+	match (os, branch) {
+		(Os::Windows, Branch::Stable) => make_statics!(),
+		(Os::Windows, Branch::Beta) => make_statics!(),
+		(Os::MacOs, Branch::Stable) => make_statics!(),
+		(Os::MacOs, Branch::Beta) => make_statics!(),
+		(Os::Linux, Branch::Stable) => make_statics!(),
+		(Os::Linux, Branch::Beta) => make_statics!(),
+	}
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum Os {
+	Windows,
+	MacOs,
+	Linux,
+}
+
+impl Os {
+	pub fn info_for_version(self, version: &str) -> serde_json::Value {
+		match self {
+			Os::Windows => serde_json::json!({
+				"version": version,
+				"updateexe": format!(
+					"https://github.com/SevenTV/chatterino7/releases/download/v{}/Chatterino7.Installer.exe", version
+				),
+				"portable_download": format!(
+					"https://github.com/SevenTV/chatterino7/releases/download/v{}/Chatterino7.Portable.zip", version
+				),
+			}),
+			Os::MacOs => serde_json::json!({
+				"version": version,
+				"updateexe": format!(
+					"https://github.com/SevenTV/chatterino7/releases/download/v{}/Chatterino.dmg", version
+				),
+			}),
+			Os::Linux => serde_json::json!({
+				"version": version,
+				"updateguide": format!(
+					"https://github.com/SevenTV/chatterino7/releases/tag/v{}", version
+				),
+			}),
+		}
+	}
+}
+
+impl FromStr for Os {
+	type Err = ();
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		match s {
+			"win" => Ok(Self::Windows),
+			"macos" => Ok(Self::MacOs),
+			"linux" => Ok(Self::Linux),
+			_ => Err(()),
+		}
+	}
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum Branch {
+	Stable,
+	Beta,
+}
+
+impl Branch {
+	pub fn resolve(self, global: &Global) -> &str {
+		match self {
+			Branch::Stable => &global.config.api.chatterino.stable_version,
+			Branch::Beta => global
+				.config
+				.api
+				.chatterino
+				.beta_version
+				.as_deref()
+				.unwrap_or(&global.config.api.chatterino.stable_version),
+		}
+	}
+}
+
+impl FromStr for Branch {
+	type Err = ();
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		match s {
+			"stable" => Ok(Self::Stable),
+			"beta" => Ok(Self::Beta),
+			_ => Err(()),
+		}
+	}
+}

--- a/apps/api/src/http/v3/rest/mod.rs
+++ b/apps/api/src/http/v3/rest/mod.rs
@@ -6,6 +6,7 @@ use crate::global::Global;
 
 pub mod auth;
 pub mod bridge;
+pub mod chatterino;
 pub mod config;
 pub mod emote_sets;
 pub mod emotes;
@@ -15,6 +16,7 @@ pub mod users;
 
 pub fn routes() -> Router<Arc<Global>> {
 	Router::new()
+		.nest("/chatterino", chatterino::routes())
 		.nest("/config", config::routes())
 		.nest("/auth", auth::routes())
 		.nest("/emotes", emotes::routes())


### PR DESCRIPTION
## Proposed changes

Adds `/v3/chatterino/version/{os}/{branch}` as described in https://github.com/SevenTV/SevenTV/issues/48 (but for v3, not v4). This basically serves a static(-ish) JSON blob for each of the combinations `win|macos|linux` x `stable|beta`.
I don't know how often the API is updated or how easy it is to do so. In the APIv2 days, this was done similarly (i.e. the API had to be updated).

I tested this locally with a modified Chatterino7 instance (that uses localhost for updates[^1]) on Windows. The relevant Chatterino7 code is here: https://github.com/SevenTV/chatterino7/blob/737cbdd63a4bdb84885e23caf76ad596c3d41e32/src/singletons/Updates.cpp#L313-L433 (it's a bit outdated because it tries to use v2 before v3).

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged

[^1]: It would be great if there was better documentation for local setups. I hacked my way through with nix to get ffmpeg 7.x and had to look through mongodb docs for the correct connection string.
