### PR TITLE
Revert tag order

### DIFF
--- a/apps/website/src/components/input/tags-input.svelte
+++ b/apps/website/src/components/input/tags-input.svelte
@@ -45,7 +45,7 @@
 			tags.length < LIMIT &&
 			!tags.includes(sanitizedTagInput)
 		) {
-			tags = [sanitizedTagInput, ...tags];
+			tags = [...tags, sanitizedTagInput];
 			tagInput = "";
 		}
 	}


### PR DESCRIPTION
## Proposed changes

Revert the tag order to "left to right"

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
