### PR TITLE
chore: update chatterino beta version

### DIFF
--- a/apps/api/src/config.rs
+++ b/apps/api/src/config.rs
@@ -140,7 +140,7 @@ pub struct ChatterinoConfig {
 	pub stable_version: String,
 
 	/// Current beta version (without the 'v' prefix, [None] if there's no beta version)
-	#[default(None)]
+	#[default("7.5.4-beta.1".to_owned().into())]
 	pub beta_version: Option<String>,
 }
 


### PR DESCRIPTION
## Proposed changes

Sets the default beta version in the `ChatterinoConfig` to the current beta (https://github.com/SevenTV/chatterino7/releases/tag/v7.5.4-beta.1).

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
