### PR TITLE
Fix discord connection button on user profile

### DIFF
--- a/apps/website/src/components/users/connections.svelte
+++ b/apps/website/src/components/users/connections.svelte
@@ -17,6 +17,8 @@
 				return `https://youtube.com/@${connection.platformUsername}`;
 			case Platform.Kick:
 				return `https://kick.com/${connection.platformUsername}`;
+			case Platform.Discord:
+				return `https://discord.com/users/${connection.platformId}`;
 			default:
 				return undefined;
 		}

--- a/apps/website/src/routes/users/[id]/+layout.ts
+++ b/apps/website/src/routes/users/[id]/+layout.ts
@@ -14,6 +14,7 @@ export function load({ fetch, params }: LayoutLoadEvent) {
 							id
 							connections {
 								platform
+        						platformId
 								platformUsername
 								platformDisplayName
 							}


### PR DESCRIPTION
## Proposed changes

Makes the discord connection clickable on user profile

<img width="235" height="225" alt="image" src="https://github.com/user-attachments/assets/a68c6239-ab66-4fa5-a814-66f756c4130b" />

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged
