### PR TITLE
Added small animation and glow when hovering the "Why 7TV?" boxes

### DIFF
--- a/apps/website/src/components/landing/feature.svelte
+++ b/apps/website/src/components/landing/feature.svelte
@@ -5,12 +5,13 @@
 		description: string;
 		link: string;
 		href: string;
+		animationDelay?: number;
 	}
 
-	let { image, title, description, link, href }: Props = $props();
+	let { image, title, description, link, href, animationDelay = 0 }: Props = $props();
 </script>
 
-<div class="feature">
+<div class="feature" style="--animation-delay: {animationDelay}s">
 	<div class="background"></div>
 	<div class="content">
 		<img src={image} alt={title} />
@@ -26,6 +27,23 @@
 
 		position: relative;
 		z-index: 0;
+		transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+
+		&:hover {
+			.content {
+				background-color: rgba(121, 121, 121, 0.08);
+				border-color: rgba(255, 255, 255, 0.2);
+				box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+				
+				img {
+					animation: float 4s linear infinite !important;
+					animation-fill-mode: both !important;
+					will-change: transform;
+					backface-visibility: hidden;
+					transform: translateZ(0);
+				}
+			}
+		}
 
 		.background {
 			position: absolute;
@@ -52,9 +70,16 @@
 			border-radius: 1.5rem;
 			border: 1px solid var(--border-active);
 			background-color: rgba(121, 121, 121, 0.04);
+			
+			transition: 
+				background-color 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+				border-color 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+				box-shadow 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 
 			img {
 				height: 6.25rem;
+				transform-origin: center center;
+				transition: transform 0.3s ease-in-out;
 			}
 
 			h3 {
@@ -78,6 +103,20 @@
 				font-size: 1rem;
 				font-weight: 600;
 			}
+		}
+	}
+
+	@keyframes float {
+		0% {
+			transform: translate3d(0, 0px, 0) rotate(0deg);
+			animation-timing-function: cubic-bezier(0.445, 0.05, 0.55, 0.95);
+		}
+		50% {
+			transform: translate3d(0, -12px, 0) rotate(0deg);
+			animation-timing-function: cubic-bezier(0.445, 0.05, 0.55, 0.95);
+		}
+		100% {
+			transform: translate3d(0, 0px, 0) rotate(0deg);
 		}
 	}
 </style>


### PR DESCRIPTION
This enhances the visual interactivity of the "Why 7TV?" section by adding a subtle hover animation and glow effect to each feature box. When users move their cursor over a box, it now gently animates and emits a soft glow.

## Proposed changes

# BEFORE

![before-ezgif com-crop](https://github.com/user-attachments/assets/420f66ef-b3b0-40c1-ad07-4ea01557122b)

# AFTER
![after](https://github.com/user-attachments/assets/924eb519-79d2-4331-b4bb-764140bde434)


## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
