### PR TITLE
style(website): fix ESLint errors and remove unused CSS selectors

### DIFF
--- a/apps/website/src/components/dialogs/admin-assign-entitlement-dialog.svelte
+++ b/apps/website/src/components/dialogs/admin-assign-entitlement-dialog.svelte
@@ -11,7 +11,6 @@
 	import type { DialogMode } from "./dialog.svelte";
 	import { t } from "svelte-i18n";
 	import Dialog from "./dialog.svelte";
-	import { t } from "svelte-i18n";
 
 	interface Props {
 		mode: DialogMode;

--- a/apps/website/src/components/landing/heroPickems.svelte
+++ b/apps/website/src/components/landing/heroPickems.svelte
@@ -130,13 +130,6 @@
 		position: absolute;
 		pointer-events: none;
 		bottom: 0;
-		img {
-			display: inline;
-			width: 100%;
-			position: relative;
-			margin-bottom: -13.5%;
-			height: 100%;
-		}
 	}
 	.hero {
 		display: flex;

--- a/apps/website/src/components/nav/top-tabs.svelte
+++ b/apps/website/src/components/nav/top-tabs.svelte
@@ -6,7 +6,7 @@
 		name: string;
 		pathname: string;
 		highlight?: string;
-		arrow?: Boolean;
+		arrow?: boolean;
 	};
 
 	let { tabs }: { tabs: Tab[] } = $props();

--- a/apps/website/src/components/pickems/pickems-badges.svelte
+++ b/apps/website/src/components/pickems/pickems-badges.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { Badge } from "$/gql/graphql";
 	import BadgeComponent from "../badge.svelte";
-	import { t } from "svelte-i18n";
 
 	let { badges }: { badges: Badge[] } = $props();
 </script>

--- a/apps/website/src/components/pickems/pickems-paints.svelte
+++ b/apps/website/src/components/pickems/pickems-paints.svelte
@@ -4,7 +4,6 @@
 	import PaintComponent from "../paint.svelte";
 	import { fly } from "svelte/transition";
 	import { user } from "$/lib/auth";
-	import { t } from "svelte-i18n";
 
 	let { paints }: { paints: Paint[] } = $props();
 	let username = $derived($user?.mainConnection?.platformDisplayName ?? "Username");

--- a/apps/website/src/components/pickems/pickems-streamers.svelte
+++ b/apps/website/src/components/pickems/pickems-streamers.svelte
@@ -356,18 +356,6 @@
 				h3 {
 					font-size: 1rem;
 				}
-
-				a {
-					display: flex;
-					align-items: center;
-					color: grey;
-					margin-top: 0.5rem;
-					font-size: 0.875rem;
-
-					:global(svg) {
-						margin-left: 0.5rem;
-					}
-				}
 			}
 		}
 		.streamer:hover {

--- a/apps/website/src/components/pickems/purchase-button.svelte
+++ b/apps/website/src/components/pickems/purchase-button.svelte
@@ -22,8 +22,6 @@
 	let price = $derived(
 		priceFormat("EUR").format((499 + (variant?.price.amount ?? 0)) / 100 - 1.49),
 	);
-	// let discounted = $derived(priceFormat("EUR").format((300 + (variant?.price.amount ?? 0)) / 100));
-	let recurring = $derived(priceFormat("EUR").format((variant?.price.amount ?? 0) / 100));
 	let disabled = $derived(!!(variant && $isSubscribed));
 
 	let giftDialog: DialogMode = $state("hidden");

--- a/apps/website/src/components/pickems/store-section.svelte
+++ b/apps/website/src/components/pickems/store-section.svelte
@@ -5,7 +5,7 @@
 	import StoreSection from "../store/store-section.svelte";
 	import Button from "../input/button.svelte";
 	import DropDown from "../drop-down.svelte";
-	import { priceFormat, variantName } from "$/lib/utils";
+	import { priceFormat } from "$/lib/utils";
 	import { user } from "$/lib/auth";
 	import { purchasePickems } from "$/lib/pickems";
 

--- a/apps/website/src/components/store/store-pickems-banner.svelte
+++ b/apps/website/src/components/store/store-pickems-banner.svelte
@@ -22,16 +22,6 @@
 </section>
 
 <style lang="scss">
-	.csmoney-banner-image {
-		position: absolute;
-		top: 1rem;
-		right: 1rem;
-		width: 9rem;
-		height: auto;
-		@media screen and (max-width: 600px) {
-			display: none;
-		}
-	}
 	.banner {
 		position: relative;
 		z-index: 0;

--- a/apps/website/src/routes/store/+layout.svelte
+++ b/apps/website/src/routes/store/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	// PaintBrush
 	// import disabled for now
-	import { Gift, Star, Ticket } from "phosphor-svelte";
+	import { Gift, Star } from "phosphor-svelte";
 	import TabLink from "$/components/tab-link.svelte";
 	import { t } from "svelte-i18n";
 	import type { Snippet } from "svelte";


### PR DESCRIPTION
## Proposed changes

Fix errors identified by ESLint

Output from `pnpm run eslint .`
<img width="2048" height="1321" alt="image" src="https://github.com/user-attachments/assets/5b3ba6ff-e342-47ee-90b6-726e057a806f" />

## Types of changes

* Remove duplicate identifier t and unused vars (t, variantName, Ticket, recurring)
* Prefer primitive boolean over Boolean in top-tabs.svelte
* Drop unused CSS selectors:
    * .header-image img
    * .streamer-grid .streamer .info a
    * .streamer-grid .streamer .info a :global(svg)
    * .csmoney-banner-image
* Resolve type issues in components using strict TS rules
* Run ESLint and apply safe auto-fixes for remaining style warnings

All apps/website checks pass locally after changes.

To test run `pnpm exec eslint .` and ensure it doesn't show an error.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged
