### PR TITLE
Added existing translation to other "Manage Personal Emote Set" element

### DIFF
--- a/apps/website/src/components/dialogs/editor-permissions-dialog.svelte
+++ b/apps/website/src/components/dialogs/editor-permissions-dialog.svelte
@@ -92,7 +92,7 @@
 					<Checkbox value={true} disabled>Manage Billing</Checkbox>
 					<Checkbox value={true} disabled>Manage Profile</Checkbox>
 					<Checkbox value={true} disabled>Manage Editors</Checkbox>
-					<Checkbox value={true} disabled>Manage Personal Emote Set</Checkbox>
+					<Checkbox value={true} disabled>{$t("dialogs.editor.manage_personal_emotes")}</Checkbox>
 				{:else}
 					<Checkbox bind:value={permissions.user.manageBilling}>Manage Billing</Checkbox>
 					<Checkbox bind:value={permissions.user.manageProfile}>Manage Profile</Checkbox>


### PR DESCRIPTION
## Proposed changes

"Manage Personal Emote Set" appears twice in the JSX looking thing, but only one used the translation token. I changed that.

I'd also be suggesting to rename the name space for these and add the other ones, but 🤷 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
