### PR TITLE
[ADDED] - Copy CDN Link (2x AVIF) & A Emote Set Context Menu

### DIFF
--- a/apps/website/src/components/emote-context-menu.svelte
+++ b/apps/website/src/components/emote-context-menu.svelte
@@ -24,9 +24,7 @@
 	let addEmoteDialogMode = $state<DialogMode>("hidden");
 
 	$effect(() => {
-		if (addEmoteDialogMode === "hidden") {
-			hide();
-		}
+		if (addEmoteDialogMode === "hidden") hide();
 	});
 
 	function showAddEmoteDialog() {
@@ -34,8 +32,43 @@
 	}
 
 	function copyLink() {
-		navigator.clipboard.writeText(new URL(`/emotes/${data.id}`, $page.url).href);
+		const url = new URL(`/emotes/${data.id}`, $page.url).href;
+		navigator.clipboard.writeText(url);
 		hide();
+		showToast("Emote link copied!");
+	}
+
+	function copyCdn2x() {
+ 	   if (!data || !data.id) return;
+
+ 	  const emoteId = data.id;
+ 	   const url = `https://cdn.7tv.app/emote/${emoteId}/2x.avif`;
+
+    	navigator.clipboard.writeText(url)
+        	.then(() => showToast("2x CDN link copied!"))
+        	.catch(() => showToast("Failed to copy CDN link!"));
+
+    	hide();
+	}
+
+
+	function showToast(message: string) {
+		const toast = document.createElement("div");
+		toast.textContent = message;
+		Object.assign(toast.style, {
+			position: "fixed",
+			bottom: "2rem",
+			left: "50%",
+			transform: "translateX(-50%)",
+			background: "var(--bg-dark)",
+			color: "white",
+			padding: "0.5rem 1rem",
+			borderRadius: "0.25rem",
+			zIndex: "9999",
+			fontSize: "0.875rem",
+		});
+		document.body.appendChild(toast);
+		setTimeout(() => toast.remove(), 2000);
 	}
 
 	function onContextMenu(e: MouseEvent) {
@@ -44,7 +77,6 @@
 </script>
 
 {#if position}
-	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div
 		class="contextmenu-container"
 		transition:fade={{ duration: 100 }}
@@ -59,24 +91,25 @@
 			{#if $user}
 				<EmoteUseButton {data} big oncomplete={hide} />
 				<AddEmoteDialog bind:mode={addEmoteDialogMode} {data} />
-				<Button big onclick={showAddEmoteDialog}>
-					{#snippet icon()}
-						<FolderSimple />
-					{/snippet}
+				<Button big on:click={showAddEmoteDialog}>
+					{#snippet icon()}<FolderSimple />{/snippet}
 					Add Emote to...
 				</Button>
 			{/if}
-			<Button big href="/emotes/{data.id}" target="_blank" onclick={hide}>
-				{#snippet icon()}
-					<ArrowSquareOut />
-				{/snippet}
+
+			<Button big href="/emotes/{data.id}" target="_blank" on:click={hide}>
+				{#snippet icon()}<ArrowSquareOut />{/snippet}
 				Open in New Tab
 			</Button>
-			<Button big onclick={copyLink}>
-				{#snippet icon()}
-					<Clipboard />
-				{/snippet}
+
+			<Button big on:click={copyLink}>
+				{#snippet icon()}<Clipboard />{/snippet}
 				Copy Emote Link
+			</Button>
+
+			<Button big on:click={copyCdn2x}>
+    			{#snippet icon()}<Clipboard />{/snippet}
+			    Copy CDN Link (2x)
 			</Button>
 		</nav>
 	</div>
@@ -89,18 +122,17 @@
 		left: 0;
 		bottom: 0;
 		right: 0;
-
 		z-index: 100;
 		pointer-events: all;
 
 		.contextmenu {
 			position: absolute;
-
 			border-radius: 0.5rem;
-
 			display: flex;
 			flex-direction: column;
 			background-color: var(--bg-light);
+			padding: 0.5rem;
+			z-index: 150;
 		}
 	}
 </style>

--- a/apps/website/src/components/emote-context-menu.svelte
+++ b/apps/website/src/components/emote-context-menu.svelte
@@ -31,6 +31,19 @@
 		addEmoteDialogMode = "shown";
 	}
 
+	let toastMessage = $state<string | null>(null);
+	let toastVisible = $state(false);
+
+	function showToast(message: string) {
+		toastMessage = message;
+		toastVisible = true;
+
+		setTimeout(() => {
+			toastVisible = false;
+			toastMessage = null;
+		}, 2000);
+	}
+
 	function copyLink() {
 		const url = new URL(`/emotes/${data.id}`, $page.url).href;
 		navigator.clipboard.writeText(url);
@@ -39,36 +52,17 @@
 	}
 
 	function copyCdn2x() {
- 	   if (!data || !data.id) return;
+		if (!data || !data.id) return;
 
- 	  const emoteId = data.id;
- 	   const url = `https://cdn.7tv.app/emote/${emoteId}/2x.avif`;
+		const emoteId = data.id;
+		const url = `https://cdn.7tv.app/emote/${emoteId}/2x.avif`;
 
-    	navigator.clipboard.writeText(url)
-        	.then(() => showToast("2x CDN link copied!"))
-        	.catch(() => showToast("Failed to copy CDN link!"));
+		navigator.clipboard
+			.writeText(url)
+			.then(() => showToast("2x CDN link copied!"))
+			.catch(() => showToast("Failed to copy CDN link!"));
 
-    	hide();
-	}
-
-
-	function showToast(message: string) {
-		const toast = document.createElement("div");
-		toast.textContent = message;
-		Object.assign(toast.style, {
-			position: "fixed",
-			bottom: "2rem",
-			left: "50%",
-			transform: "translateX(-50%)",
-			background: "var(--bg-dark)",
-			color: "white",
-			padding: "0.5rem 1rem",
-			borderRadius: "0.25rem",
-			zIndex: "9999",
-			fontSize: "0.875rem",
-		});
-		document.body.appendChild(toast);
-		setTimeout(() => toast.remove(), 2000);
+		hide();
 	}
 
 	function onContextMenu(e: MouseEvent) {
@@ -108,10 +102,16 @@
 			</Button>
 
 			<Button big on:click={copyCdn2x}>
-    			{#snippet icon()}<Clipboard />{/snippet}
-			    Copy CDN Link (2x)
+				{#snippet icon()}<Clipboard />{/snippet}
+				Copy CDN Link (2x)
 			</Button>
 		</nav>
+	</div>
+{/if}
+
+{#if toastVisible && toastMessage}
+	<div class="toast" transition:fade={{ duration: 100 }}>
+		{toastMessage}
 	</div>
 {/if}
 
@@ -134,5 +134,19 @@
 			padding: 0.5rem;
 			z-index: 150;
 		}
+	}
+
+	.toast {
+		position: fixed;
+		bottom: 2rem;
+		left: 50%;
+		transform: translateX(-50%);
+		background: var(--bg-dark);
+		color: white;
+		padding: 0.5rem 1rem;
+		border-radius: 0.25rem;
+		z-index: 9999;
+		font-size: 0.875rem;
+		pointer-events: none;
 	}
 </style>

--- a/apps/website/src/components/emote-set-preview.svelte
+++ b/apps/website/src/components/emote-set-preview.svelte
@@ -5,6 +5,9 @@
 	import Flags, { determineHighlightColor, emoteSetToFlags } from "./flags.svelte";
 	import ResponsiveImage from "./responsive-image.svelte";
 
+	// NEW: import the set context menu
+	import SetContextMenu from "./set-context-menu.svelte";
+
 	type Props = {
 		data: EmoteSet;
 		bg?: "medium" | "light";
@@ -13,29 +16,31 @@
 	let { data, bg = "medium" }: Props = $props();
 
 	let flags = $derived(emoteSetToFlags(data, $user, $defaultEmoteSet));
-
 	let highlight = $derived(determineHighlightColor(flags));
 
 	let usage = $derived.by(() => {
 		if (!data.capacity) return undefined;
-
 		if (data.emotes.totalCount === 0) return 0;
-
 		return Math.round((data.emotes.totalCount / data.capacity) * 100);
 	});
 
 	let emotePreviews = $derived(
-		data.emotes.items.filter((emote) => emote.emote).map((emote) => emote.emote!),
+		data.emotes.items.filter((emote) => emote.emote).map((emote) => emote.emote!)
 	);
 
 	let placeholderCount = $derived.by(() => {
 		let slots = 12;
-		if (data.capacity) {
-			slots = Math.min(data.capacity, slots);
-		}
-
+		if (data.capacity) slots = Math.min(data.capacity, slots);
 		return Math.max(slots - emotePreviews.length, 0);
 	});
+
+	let contextPosition = $state<{ x: number; y: number } | undefined>(undefined);
+
+	function openContextMenu(e: MouseEvent) {
+		e.preventDefault();
+		e.stopPropagation();
+		contextPosition = { x: e.clientX, y: e.clientY };
+	}
 </script>
 
 <a
@@ -45,6 +50,7 @@
 		? `--highlight: ${highlight}80; --highlight-active: ${highlight};`
 		: "--highlight: transparent; --highlight-active: var(--border-active);"}
 	style:background-color="var(--bg-{bg})"
+	oncontextmenu={openContextMenu}
 >
 	<div class="emotes" style:grid-template-columns="repeat({Math.min(data.capacity ?? 6, 6)}, 1fr)">
 		{#each emotePreviews as emote, i}
@@ -55,7 +61,6 @@
 				style="max-height: 2rem; overflow: hidden"
 			/>
 		{/each}
-		<!-- Fill remaining slots (if any) with placeholders -->
 		{#each Array(placeholderCount) as _}
 			<div class="placeholder"></div>
 		{/each}
@@ -70,39 +75,32 @@
 	{/if}
 </a>
 
+<SetContextMenu setId={data.id} bind:position={contextPosition} />
+
 <style lang="scss">
 	.emote-set {
 		color: var(--text);
 		text-decoration: none;
-
 		display: grid;
 		align-items: start;
 		grid-template-rows: 1fr auto auto;
 		gap: 0.5rem;
-
 		padding: 1rem;
 		border: 1px solid transparent;
 		border-radius: 0.25rem;
 		cursor: pointer;
-
 		border-color: var(--highlight);
-
-		&:hover,
-		&:focus-visible {
-			border-color: var(--highlight-active);
-		}
+		&:hover, &:focus-visible { border-color: var(--highlight-active); }
 	}
 
 	.emotes {
 		grid-column: span 2;
 		align-self: stretch;
 		margin-bottom: 0.5rem;
-
 		display: grid;
 		justify-items: center;
 		align-items: center;
 		gap: 0.5rem;
-
 		& > .placeholder {
 			width: 2rem;
 			height: 2rem;
@@ -121,36 +119,21 @@
 
 	.usage {
 		position: relative;
-
 		grid-column: span 2;
-
 		display: flex;
 		justify-content: center;
-
 		& > progress[value] {
 			position: absolute;
 			width: 100%;
 			height: 100%;
-
 			background-color: var(--bg-light);
-
-			&::-webkit-progress-bar {
-				background-color: var(--bg-light);
-			}
-
-			&::-moz-progress-bar {
-				background-color: var(--secondary);
-			}
-
-			&::-webkit-progress-value {
-				background-color: var(--secondary);
-			}
+			&::-webkit-progress-bar { background-color: var(--bg-light); }
+			&::-moz-progress-bar { background-color: var(--secondary); }
+			&::-webkit-progress-value { background-color: var(--secondary); }
 		}
-
 		& > span {
 			z-index: 1;
 			padding: 0.3rem;
-
 			text-align: center;
 			font-size: 0.75rem;
 			font-weight: 500;

--- a/apps/website/src/components/set-context-menu.svelte
+++ b/apps/website/src/components/set-context-menu.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+	import { ArrowSquareOut, Clipboard, FolderSimple } from "phosphor-svelte";
+	import AddEmoteDialog from "./dialogs/add-emote-dialog.svelte";
+	import Button from "./input/button.svelte";
+	import mouseTrap from "$/lib/mouseTrap";
+	import { page } from "$app/stores";
+	import { fade } from "svelte/transition";
+	import { user } from "$/lib/auth";
+	import type { DialogMode } from "./dialogs/dialog.svelte";
+
+	interface Props {
+		setId: string;
+		position?: { x: number; y: number };
+	}
+
+	let { setId, position = $bindable() }: Props = $props();
+
+	function hide() {
+		position = undefined;
+	}
+
+	let addEmoteDialogMode = $state<DialogMode>("hidden");
+
+	$effect(() => {
+		if (addEmoteDialogMode === "hidden") {
+			hide();
+		}
+	});
+
+	function showAddEmoteDialog() {
+		addEmoteDialogMode = "shown";
+	}
+
+	function copyLink() {
+		navigator.clipboard.writeText(new URL(`/emote-sets/${setId}`, $page.url).href);
+		hide();
+	}
+
+	function onContextMenu(e: MouseEvent) {
+		e.preventDefault();
+	}
+</script>
+
+{#if position}
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div
+		class="contextmenu-container"
+		transition:fade={{ duration: 100 }}
+		oncontextmenu={onContextMenu}
+	>
+		<nav
+			class="contextmenu"
+			use:mouseTrap={hide}
+			style:left="{position.x}px"
+			style:top="{position.y}px"
+		>
+			{#if $user}
+				<AddEmoteDialog bind:mode={addEmoteDialogMode} setId={setId} />
+				<Button big onclick={showAddEmoteDialog}>
+					{#snippet icon()}
+						<FolderSimple />
+					{/snippet}
+					Add Emote to...
+				</Button>
+			{/if}
+			<Button big href="/emote-sets/{setId}" target="_blank" onclick={hide}>
+				{#snippet icon()}
+					<ArrowSquareOut />
+				{/snippet}
+				Go To Set
+			</Button>
+			<Button big onclick={copyLink}>
+				{#snippet icon()}
+					<Clipboard />
+				{/snippet}
+				Copy Set Link
+			</Button>
+		</nav>
+	</div>
+{/if}
+
+<style lang="scss">
+	.contextmenu-container {
+		position: fixed;
+		top: 0;
+		left: 0;
+		bottom: 0;
+		right: 0;
+
+		z-index: 100;
+		pointer-events: all;
+
+		.contextmenu {
+			position: absolute;
+
+			border-radius: 0.5rem;
+
+			display: flex;
+			flex-direction: column;
+			background-color: var(--bg-light);
+		}
+	}
+</style>


### PR DESCRIPTION
## Proposed changes

I added a new feature to give the option to copy the CDN (2x AVIF) URL of a emote when you right click. Also added a emote set context menu similar to the emote context menu but for the emote set.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
