### PR TITLE
fix(website): offline auto-retry for emote pages + WebSocket reconnect

### DIFF
--- a/apps/website/src/locales/en.json
+++ b/apps/website/src/locales/en.json
@@ -65,7 +65,8 @@
 		"profile": "Profile",
 		"pinned": "Pinned",
 		"settings": "Settings",
-		"delete_account": "Delete Account"
+		"delete_account": "Delete Account",
+		"offline_retry": "No internet connection — will retry automatically when online"
 	},
 	"labels": {
 		"enter_text": "Enter text",

--- a/apps/website/src/routes/emotes/[id]/+layout.svelte
+++ b/apps/website/src/routes/emotes/[id]/+layout.svelte
@@ -3,24 +3,67 @@
 	import { t } from "svelte-i18n";
 	import EmoteInfo from "$/components/emotes/emote-info.svelte";
 	import type { Snippet } from "svelte";
+	import { invalidate } from "$app/navigation";
+	import { browser } from "$app/environment";
+	import type { Emote } from "$/gql/graphql";
+	import { WifiX } from "phosphor-svelte";
 
 	let { data, children }: { data: LayoutData; children: Snippet } = $props();
+
+	let loadFailed = $state(false);
+	let isOnline = $state(browser ? navigator.onLine : true);
+
+	$effect(() => {
+		loadFailed = false;
+		data.streamed.emote.then((emote: Emote | undefined) => {
+			if (!emote) loadFailed = true;
+		});
+	});
+
+	$effect(() => {
+		if (!browser) return;
+
+		function handleOnline() {
+			isOnline = true;
+			if (loadFailed) {
+				invalidate(`emotes:${data.id}`);
+			}
+		}
+
+		function handleOffline() {
+			isOnline = false;
+		}
+
+		window.addEventListener("online", handleOnline);
+		window.addEventListener("offline", handleOffline);
+		return () => {
+			window.removeEventListener("online", handleOnline);
+			window.removeEventListener("offline", handleOffline);
+		};
+	});
 </script>
 
 <svelte:head>
 	{#await data.streamed.emote}
 		<title>Loading - {$t("page_titles.suffix")}</title>
 	{:then emote}
-		<title>{emote.defaultName} - {$t("page_titles.suffix")}</title>
+		<title>{emote?.defaultName ?? $t("page_titles.suffix")} - {$t("page_titles.suffix")}</title>
 	{/await}
 </svelte:head>
+
+{#if !isOnline && loadFailed}
+	<div class="offline-banner">
+		<WifiX size={18} />
+		{$t("common.offline_retry")}
+	</div>
+{/if}
 
 <div class="layout">
 	<div>
 		{#await data.streamed.emote}
 			<EmoteInfo data={null} />
 		{:then emote}
-			<EmoteInfo data={emote} />
+			<EmoteInfo data={emote ?? null} />
 		{/await}
 	</div>
 	<div>
@@ -29,6 +72,21 @@
 </div>
 
 <style lang="scss">
+	.offline-banner {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		max-width: 80rem;
+		margin-inline: auto;
+		margin-top: 0.75rem;
+		padding: 0.6rem 1rem;
+		background-color: var(--bg-medium);
+		border: 1px solid var(--danger);
+		border-radius: 0.5rem;
+		color: var(--danger);
+		font-size: 0.875rem;
+	}
+
 	.layout {
 		width: 100%;
 		max-width: 80rem;

--- a/apps/website/src/workers/eventApiWorker.ts
+++ b/apps/website/src/workers/eventApiWorker.ts
@@ -32,6 +32,10 @@ let eventApi:
 
 const ports: MessagePort[] = [];
 
+const RECONNECT_BASE_DELAY_MS = 1000;
+const RECONNECT_MAX_DELAY_MS = 30000;
+let reconnectAttempts = 0;
+
 onconnect = (event) => {
 	debug("new worker port connected");
 	const port = event.ports[0];
@@ -151,7 +155,7 @@ function subscribe(type: DispatchType, id: string, handlerId: string) {
 
 function unsubscribe(type: DispatchType, id: string, handlerId: string) {
 	if (!eventApi) {
-		eventApi = init();
+		return;
 	}
 
 	const handlers = eventApi.subscriptions.get(mapKey(type, id));
@@ -217,6 +221,7 @@ function onMessage(this: WebSocket, event: MessageEvent) {
 	if (data.op === 1) {
 		const hello = data as HelloMessage;
 		debug(`got hello from ${hello.d.instance.name}, session: ${hello.d.session_id}`);
+		reconnectAttempts = 0;
 
 		if (eventApi) {
 			eventApi.open_socket = this;
@@ -240,12 +245,7 @@ function onMessage(this: WebSocket, event: MessageEvent) {
 	if (data.op === 4) {
 		debug("reconnect requested");
 		this.close();
-
-		// Retry after 1 second
-		setTimeout(() => {
-			eventApi = init();
-		}, 1000);
-
+		reconnectWithBackoff();
 		return;
 	}
 
@@ -256,16 +256,22 @@ function onMessage(this: WebSocket, event: MessageEvent) {
 	}
 }
 
+function reconnectWithBackoff() {
+	const delay = Math.min(RECONNECT_BASE_DELAY_MS * Math.pow(2, reconnectAttempts), RECONNECT_MAX_DELAY_MS);
+	reconnectAttempts++;
+	warn(`reconnecting in ${delay}ms (attempt ${reconnectAttempts})`);
+	setTimeout(() => {
+		eventApi = init();
+	}, delay);
+}
+
 function onClose(this: WebSocket, event: CloseEvent) {
 	if (event.wasClean) {
 		log(`ws connection closed cleanly`, event.code, event.reason);
+		reconnectAttempts = 0;
 	} else {
 		warn(`ws connection closed`, event.code, event.reason);
-
-		// Retry after 1 second
-		setTimeout(() => {
-			eventApi = init();
-		}, 1000);
+		reconnectWithBackoff();
 	}
 
 	// Reset


### PR DESCRIPTION
## Proposed changes

When a user navigates to an emote page without internet (or loses connection mid-navigation), the GraphQL request silently fails and the page shows an infinite loading spinner with no recovery path - the user has to manually refresh after connection is restored. On mobile and unstable connections this is a frequent and frustrating experience. As someone with an unstable internet connection, I personally ran into this constantly: I open an emote, connection drops for a few seconds, and I'm stuck on a spinner forever. I have to notice it, realize it's not loading, and manually hit F5 - often multiple times. This PR makes the page recover on its own the moment internet comes back :)

Before:

https://github.com/user-attachments/assets/7c67487b-0ac1-4127-826a-f3b4ed0acebd

After:

https://github.com/user-attachments/assets/3f2cfa93-d3fd-44c7-a219-bed0ce740b7f

Additionally, the WebSocket EventAPI worker had two bugs: unsubscribe() incorrectly initiated a new connection when none existed, and reconnection delays were hardcoded at a flat 1 second with no backoff, causing reconnection storms under poor network conditions 0-0

1) Fixes unsubscribe() incorrectly calling init() when no connection is active - this caused a new WebSocket to be opened during component teardown, wasting resources
2) Replaces two separate hardcoded setTimeout(..., 1000) reconnect calls with a single reconnectWithBackoff() function implementing exponential backoff (1s -> 2s -> 4s -> ... -> 30s cap). The counter resets on a successful Hello message (op=1) or a clean close

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
