### PR TITLE
Fix RTL dialog close button positioning

### DIFF
--- a/apps/website/src/components/dialogs/dialog.svelte
+++ b/apps/website/src/components/dialogs/dialog.svelte
@@ -56,7 +56,7 @@
 		style="width: {width}rem"
 	>
 		{#if mode === "shown"}
-			<Button onclick={close} style="position: absolute; top: 0.5rem; right: 0.5rem;">
+			<Button onclick={close} style="position: absolute; top: 0.5rem; inset-inline-end: 0.5rem;">
 				{#snippet icon()}
 					<X />
 				{/snippet}


### PR DESCRIPTION
Fixes #284 - 'Paint' label overlaps with close button in RTL mode

## Proposed changes

Replace fixed CSS positioning for the close button in the Paint and Badge preview. The close button is now correctly positioned on the left side in RTL mode.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
