### PR TITLE
Fix sidebar height inconsistencies in sidebar layouts on /store/redeem page and /emotes page

### DIFF
--- a/apps/website/src/routes/emotes/(directory)/+layout.svelte
+++ b/apps/website/src/routes/emotes/(directory)/+layout.svelte
@@ -168,4 +168,15 @@
 		flex-direction: column;
 		gap: 1rem;
 	}
+
+	// Ensure sidebar has proper height from the start
+	.emotes-side-bar-layout {
+		height: 100vh;
+		min-height: 100vh;
+	}
+
+	.emotes-side-bar-layout > .side-bar {
+		height: calc(100vh - 2.5rem);
+		min-height: calc(100vh - 2.5rem);
+	}
 </style>

--- a/apps/website/src/routes/emotes/(directory)/+layout.svelte
+++ b/apps/website/src/routes/emotes/(directory)/+layout.svelte
@@ -171,12 +171,11 @@
 
 	// Ensure sidebar has proper height from the start
 	.emotes-side-bar-layout {
-		height: 100vh;
+		height: 100%;
 		min-height: 100vh;
 	}
 
 	.emotes-side-bar-layout > .side-bar {
-		height: calc(100vh - 2.5rem);
 		min-height: calc(100vh - 2.5rem);
 	}
 </style>

--- a/apps/website/src/routes/emotes/(directory)/+layout.svelte
+++ b/apps/website/src/routes/emotes/(directory)/+layout.svelte
@@ -169,7 +169,6 @@
 		gap: 1rem;
 	}
 
-	// Ensure sidebar has proper height from the start
 	.emotes-side-bar-layout {
 		height: 100%;
 		min-height: 100vh;

--- a/apps/website/src/routes/store/redeem/+page.svelte
+++ b/apps/website/src/routes/store/redeem/+page.svelte
@@ -120,6 +120,11 @@
 		margin-inline: auto;
 	}
 
+	.grid > :global(*) {
+		max-width: 25rem;
+		margin-inline: auto;
+	}
+
 	.redeem {
 		display: flex;
 		flex-direction: column;

--- a/apps/website/src/routes/store/redeem/+page.svelte
+++ b/apps/website/src/routes/store/redeem/+page.svelte
@@ -115,7 +115,7 @@
 	}
 
 	.grid {
-		max-width: 25rem;
+		max-width: 70rem;
 		margin-top: 1rem;
 		margin-inline: auto;
 	}


### PR DESCRIPTION
## Proposed changes

This pull request fixes visual height inconsistencies in sidebar layouts across the /store/redeem page and /emotes page. The issues were particularly noticeable during gifting events when alert bars are present and during initial page loads before content fully renders.

1. /store/redeem page 
- Problem: Sidebar appeared shorter than on /store
- Screenshot showing the issue: https://prnt.sc/XbJHscH5d-68
- Before: Container 'max-width: 25rem' -> Sidebar height inconsistent with store page
- After: Container 'max-width: 70rem' + content 'max-width: 25rem'
 
2. /emotes page 
- Problem: Initial height glitch before emotes load, causing sidebar to appear too short
- Screenshot showing the issue: https://prnt.sc/8not0SbaLkKl
- Before: Container 'height: 100%' only
- After: Container 'height: 100%' + 'min-height: 100vh' -> Stable height from page load, remains responsive
   
## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
