### PR TITLE
fix: duplicate emotes in addEmote

### DIFF
--- a/apps/api/src/http/v3/gql/mutations/emote_sets/emote_add.rs
+++ b/apps/api/src/http/v3/gql/mutations/emote_sets/emote_add.rs
@@ -45,7 +45,26 @@ pub async fn emote_add(
 		)));
 	}
 
-	let alias = name.unwrap_or_else(|| emote.default_name.clone());
+	if emote_set.emotes.iter().any(|e| e.id == emote_id) {
+		return Err(TransactionError::Custom(ApiError::conflict(
+			ApiErrorCode::BadRequest,
+			"emote is already in this set",
+		)));
+	}
+
+	let alias = match name {
+		Some(a) => a,
+		None => {
+			let n = emote.default_name.clone();
+			if !crate::http::validators::check_emote_alias(&n) {
+				return Err(TransactionError::Custom(ApiError::bad_request(
+					ApiErrorCode::BadRequest,
+					"emote default name contains invalid characters",
+				)));
+			}
+			n
+		}
+	};
 
 	// This may be a problem if the emote has been deleted.
 	// We should likely load all the emotes here anyways.

--- a/apps/api/src/http/v4/gql/mutations/emote_set/operation.rs
+++ b/apps/api/src/http/v4/gql/mutations/emote_set/operation.rs
@@ -496,7 +496,26 @@ impl EmoteSetOperation {
 					)));
 				}
 
-				let alias = id.alias.unwrap_or_else(|| db_emote.default_name.clone());
+				if emote_set.emotes.iter().any(|e| e.id == id.emote_id) {
+					return Err(TransactionError::Custom(ApiError::conflict(
+						ApiErrorCode::BadRequest,
+						"emote is already in this set",
+					)));
+				}
+
+				let alias = match id.alias {
+					Some(a) => a,
+					None => {
+						let name = db_emote.default_name.clone();
+						if !crate::http::validators::check_emote_alias(&name) {
+							return Err(TransactionError::Custom(ApiError::bad_request(
+								ApiErrorCode::BadRequest,
+								"emote default name contains invalid characters",
+							)));
+						}
+						name
+					}
+				};
 
 				// This may be a problem if the emote has been deleted.
 				// We should likely load all the emotes here anyways.


### PR DESCRIPTION
## Proposed changes

fixes #216

addEmote didn't check if the emote was already in the set, so you could add it again with a different alias and bypass capacity. also the default_name fallback wasn't going through alias validation.

fixed in both v3 and v4.

couldn't sign the CLA, cla.7tv.app is down (#260). will sign when it's back.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged