### PR TITLE
Add warning for possible new account creation

### DIFF
--- a/apps/website/src/components/dialogs/new-account-warning.svelte
+++ b/apps/website/src/components/dialogs/new-account-warning.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+	import { Warning } from "phosphor-svelte";
+	import Dialog, { type DialogMode } from "./dialog.svelte";
+	import Button from "../input/button.svelte";
+	import { t } from "svelte-i18n";
+
+	interface Props {
+		mode: DialogMode;
+		cancel?: () => void;
+		confirm?: () => void;
+		logInLast?: () => void;
+		lastPlatform: string;
+	}
+
+	let { mode = $bindable("hidden"), cancel, confirm, logInLast, lastPlatform }: Props = $props();
+
+	const confirmed = () => {
+		confirm?.();
+		mode = "hidden";
+	};
+
+	const loginLastPlatform = () => {
+		logInLast?.();
+		mode = "hidden";
+	};
+
+	const canceled = () => {
+		cancel?.();
+		mode = "hidden";
+	};
+</script>
+
+<Dialog width={40} bind:mode>
+	<div class="layout">
+		<h1>{$t("dialogs.delete_account.warning")}</h1>
+		<hr />
+		<section id="warning">
+			<Warning size="5rem" color="var(--danger)" />
+			<p id="warning-text">Are you sure you want to proceed?</p>
+			<p>We detected a previous login with {lastPlatform}.</p>
+			<p>Choose "Login with {lastPlatform}" to start the linking process for that account.</p>
+			<p>Creating a new account will make a separate account.</p>
+			<a href="https://help.7tv.app/en/articles/11068377" target="_blank">
+				Learn how to connect accounts
+			</a>
+		</section>
+		<div class="buttons">
+			<Button primary onclick={loginLastPlatform}>Login with {lastPlatform}</Button>
+			<Button style="color: var(--danger)" onclick={confirmed}>Create New Account</Button>
+			<Button secondary onclick={canceled}>{$t("labels.cancel")}</Button>
+		</div>
+	</div>
+</Dialog>
+
+<style lang="scss">
+	.layout {
+		padding: 1rem;
+
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+
+		#warning-text {
+			font-size: 1.5rem;
+			font-weight: 600;
+			color: var(--danger);
+		}
+
+		#warning {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			text-align: center;
+		}
+
+		height: 100%;
+
+		z-index: 100000000;
+	}
+
+	h1 {
+		font-size: 1rem;
+		font-weight: 600;
+	}
+
+	.buttons {
+		grid-column: span 2;
+
+		display: flex;
+		gap: 0.5rem;
+		justify-content: flex-end;
+
+		@media (max-width: 768px) {
+			flex-direction: column;
+			justify-content: stretch;
+		}
+	}
+</style>

--- a/apps/website/src/components/dialogs/sign-in-dialog.svelte
+++ b/apps/website/src/components/dialogs/sign-in-dialog.svelte
@@ -8,16 +8,23 @@
 	import { t } from "svelte-i18n";
 	import { PUBLIC_DISCORD_LINK, PUBLIC_REST_API_V4 } from "$env/static/public";
 	import { page } from "$app/stores";
+	import NewAccountWarning from "./new-account-warning.svelte";
+
+	let areYouSureDialogMode = $state<DialogMode>("hidden");
+	let lastPlatform = $state<string | null>(null);
+	let selectedPlatform = $state<string | null>(null);
 
 	let {
 		mode = $bindable("hidden"),
 		return_payload = $bindable(),
 	}: { mode: DialogMode; return_payload?: object } = $props();
 
-	let loginUrl = $derived.by(() => {
-		let url = `${PUBLIC_REST_API_V4}/auth/login?platform={platform}`;
+	function getLoginUrl(platform: string, return_to?: string): string {
+		let url = `${PUBLIC_REST_API_V4}/auth/login?platform=${platform}`;
+		
 		if ($page.url.pathname !== "/login") {
-			let return_to = $page.url.pathname;
+			if (!return_to) return_to = $page.url.pathname;
+
 			if (return_payload) {
 				return_to += "?";
 				for (const [key, val] of Object.entries(return_payload)) {
@@ -26,13 +33,31 @@
 			}
 			url += `&return_to=${return_to}`;
 		}
-		return url;
-	});
 
-	function withPlatform(platform: string) {
-		return loginUrl.replace("{platform}", platform);
+		return url;
+	}
+
+	function withPlatform(platform: string, force: boolean = false, redirect?: string) {
+		lastPlatform = JSON.parse(localStorage.getItem("lastLoggedInPlatform") || "null");
+
+		selectedPlatform = platform;
+
+		if (lastPlatform && lastPlatform.toLowerCase() !== platform.toLowerCase() && !force) {
+			areYouSureDialogMode = "shown";
+		} else {
+			window.location.href = getLoginUrl(platform, redirect);
+		}
 	}
 </script>
+
+{#if lastPlatform}
+	<NewAccountWarning
+		bind:mode={areYouSureDialogMode}
+		{lastPlatform}
+		logInLast={() => lastPlatform && withPlatform(lastPlatform, false, "/settings")}
+		confirm={() => selectedPlatform && withPlatform(selectedPlatform, true)}
+	/>
+{/if}
 
 <Dialog bind:mode>
 	<div class="layout">
@@ -42,19 +67,19 @@
 			<span class="details">{$t("dialogs.sign_in.subtitle")}</span>
 		</div>
 		<div class="buttons">
-			<Button secondary big href={withPlatform("twitch")}>
+			<Button secondary big onclick={() => withPlatform("twitch")}>
 				{#snippet icon()}
 					<TwitchLogo />
 				{/snippet}
 				{$t("dialogs.sign_in.continue_with", { values: { platform: "Twitch" } })}
 			</Button>
-			<Button secondary big href={withPlatform("discord")}>
+			<Button secondary big onclick={() => withPlatform("discord")}>
 				{#snippet icon()}
 					<DiscordLogo />
 				{/snippet}
 				{$t("dialogs.sign_in.continue_with", { values: { platform: "Discord" } })}
 			</Button>
-			<Button secondary big href={withPlatform("kick")}>
+			<Button secondary big onclick={() => withPlatform("kick")}>
 				{#snippet icon()}
 					<KickLogo />
 				{/snippet}

--- a/apps/website/src/routes/link/callback/+page.ts
+++ b/apps/website/src/routes/link/callback/+page.ts
@@ -47,6 +47,8 @@ export async function load({ url, fetch }: PageLoadEvent) {
 				throw await res.json();
 			}
 
+			localStorage.setItem("lastLoggedInPlatform", JSON.stringify(platform));
+
 			return;
 		})
 		.catch((res) => {


### PR DESCRIPTION
## Proposed changes

This aims to reduce the huge amount of account merge requests caused by accidentally creating new accounts instead of linking them to already existing one.

If user main account doesn't have any connections other than 1, then tries to log in with a different platform which will result in new account creation.

When user successfully logs into eg. twitch, it will save it as the last login platform.
If found to use different platform to log in, the dialog will show up.
The dialog should not occur if user doesn't have any platform saved.

# Flowchart
<img width="1573" height="545" alt="image" src="https://github.com/user-attachments/assets/ee26bc64-ce6d-4b98-9bdb-f6985aeb46a7" />

# Previews 

PC:
<img width="329" height="263" alt="localhost_4173_ (2) (1)" src="https://github.com/user-attachments/assets/bd07079b-ff0d-4a5c-ae8a-c86259d30818" />

Mobile:
<img width="323" height="361" alt="localhost_4173_(iPhone 14 Pro Max) (1) (2)" src="https://github.com/user-attachments/assets/13962b5a-4e8e-46aa-8e8f-2af7f4878ebb" />

What each buttons does:
Login with "x" (defaults to last logged in platform) - Logs in with the given platform, after logging redirects to **/settings** where connections can be found
Create New Account - Creates a new account
Cancel - Cancels

Currently the only issue I can see is:
(assuming if user has 2 or more connections) If user was logged in with eg. twitch, but they log out and try to log in with eg. kick then this popout will show up.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged
