### PR TITLE
(New Feature) Preview for unselected badges

### DIFF
--- a/apps/website/src/routes/users/[id]/cosmetics/+page.svelte
+++ b/apps/website/src/routes/users/[id]/cosmetics/+page.svelte
@@ -441,7 +441,7 @@
 								? 0.5
 								: 1};"
 						>
-							<BadgeComponent {badge} size={2 * 16} enableDialog={activeBadge === badge.id} />
+							<BadgeComponent {badge} size={2 * 16} enableDialog={!editingEnabled || activeBadge === badge.id} />
 							<span class="name">{badge.name}</span>
 							{#if badgesLayout === "list"}
 								<span class="description">{badge.description}</span>


### PR DESCRIPTION
## Proposed changes

This new added feature allows 7TV users to preview their badges without actually selecting them (just like you can already do so with paints).

The feature has been tested and corresponding screenshots have been taken:

<img width="1896" height="991" alt="grafik" src="https://github.com/user-attachments/assets/a585b726-df5c-4b94-a1a3-e78be0256e68" />

The image above shows that a badge is previewed without selecting it.

## Types of changes

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged
