### PR TITLE
(Feature) Improved emote activity feed + added emote info tab

### DIFF
--- a/apps/website/src/components/dialogs/trending-emotes-dialog.svelte
+++ b/apps/website/src/components/dialogs/trending-emotes-dialog.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+	import Dialog, { type DialogMode } from "./dialog.svelte";
+	import { gqlClient } from "$/lib/gql";
+	import { graphql } from "$/gql";
+	import { type Image, type SortBy } from "$/gql/graphql";
+	import ResponsiveImage from "../responsive-image.svelte";
+	import Spinner from "../spinner.svelte";
+	import Button from "../input/button.svelte";
+	import { t } from "svelte-i18n";
+
+	interface Props {
+		mode: DialogMode;
+		sortBy: SortBy;
+		title: string;
+	}
+
+	let { mode = $bindable("hidden"), sortBy, title }: Props = $props();
+
+	type TopEmoteItem = { id: string; defaultName: string; images: Image[] };
+
+	// Server allows up to perPage: 250 / page: 100 for this query (see EmoteQuery::search
+	// in apps/api). 100 per page keeps a single request quick while still allowing "Load more"
+	// to page through everything the server has for this ranking category.
+	const PER_PAGE = 100;
+
+	let items = $state<TopEmoteItem[]>([]);
+	let page = $state(1);
+	let loading = $state(false);
+	let loadError = $state(false);
+	let hasMore = $state(true);
+
+	async function fetchPage(sortBy: SortBy, page: number): Promise<TopEmoteItem[]> {
+		const res = await gqlClient()
+			.query(
+				graphql(`
+					query TrendingEmotesList($sortBy: SortBy!, $page: Int!, $perPage: Int!) {
+						emotes {
+							search(sort: { sortBy: $sortBy, order: DESCENDING }, page: $page, perPage: $perPage) {
+								items {
+									id
+									defaultName
+									images {
+										url
+										mime
+										size
+										width
+										height
+										scale
+										frameCount
+									}
+								}
+							}
+						}
+					}
+				`),
+				{ sortBy, page, perPage: PER_PAGE },
+			)
+			.toPromise();
+
+		if (res.error || !res.data) {
+			throw res.error;
+		}
+
+		return res.data.emotes.search.items;
+	}
+
+	async function loadFirstPage(sortBy: SortBy) {
+		items = [];
+		page = 1;
+		hasMore = true;
+		loadError = false;
+		loading = true;
+
+		try {
+			const results = await fetchPage(sortBy, 1);
+			items = results;
+			hasMore = results.length === PER_PAGE;
+		} catch (error) {
+			console.error("Failed to load trending emotes list", error);
+			loadError = true;
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function loadMore() {
+		if (loading || !hasMore) return;
+
+		loading = true;
+		const nextPage = page + 1;
+
+		try {
+			const results = await fetchPage(sortBy, nextPage);
+			items = [...items, ...results];
+			page = nextPage;
+			hasMore = results.length === PER_PAGE;
+		} catch (error) {
+			console.error("Failed to load more trending emotes", error);
+			hasMore = false;
+		} finally {
+			loading = false;
+		}
+	}
+
+	// (Re)load whenever the dialog is opened, and whenever it's reused for a different
+	// ranking category (trending week vs. top all-time) while already open.
+	$effect(() => {
+		if (mode !== "hidden") {
+			loadFirstPage(sortBy);
+		}
+	});
+</script>
+
+<Dialog width={26} bind:mode>
+	<div class="layout">
+		<h1>{title}</h1>
+		<hr />
+		<div class="list">
+			{#each items as emote, index}
+				<a href="/emotes/{emote.id}" class="row">
+					<span class="rank">#{index + 1}</span>
+					<ResponsiveImage images={emote.images} width={32} height={32} />
+					<span class="name">{emote.defaultName}</span>
+				</a>
+			{/each}
+			{#if !loading && !loadError && items.length === 0}
+				<p class="empty">{$t("pages.emote.info.trending_list_empty")}</p>
+			{/if}
+			{#if loading}
+				<div class="spinner-wrapper">
+					<Spinner />
+				</div>
+			{/if}
+			{#if loadError}
+				<p class="empty error">{$t("pages.emote.info.trending_list_error")}</p>
+			{/if}
+		</div>
+		{#if !loading && hasMore && items.length > 0}
+			<Button secondary onclick={loadMore}>{$t("pages.emote.info.trending_list_load_more")}</Button>
+		{/if}
+	</div>
+</Dialog>
+
+<style lang="scss">
+	.layout {
+		padding: 1rem;
+
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+
+		max-height: 80vh;
+	}
+
+	h1 {
+		font-size: 1rem;
+		font-weight: 600;
+	}
+
+	.list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		overflow-y: auto;
+	}
+
+	.row {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+
+		padding: 0.4rem 0.5rem;
+		border-radius: 0.35rem;
+		color: var(--text);
+		text-decoration: none;
+
+		&:hover,
+		&:focus-visible {
+			background-color: var(--bg-light);
+		}
+	}
+
+	.rank {
+		width: 2.5rem;
+		flex-shrink: 0;
+		font-size: 0.8rem;
+		font-weight: 600;
+		color: var(--text-light);
+	}
+
+	.name {
+		font-size: 0.85rem;
+		font-weight: 500;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.spinner-wrapper {
+		text-align: center;
+		padding: 1rem 0;
+	}
+
+	.empty {
+		color: var(--text-light);
+		font-size: 0.85rem;
+		text-align: center;
+		padding: 1rem 0;
+	}
+
+	.empty.error {
+		color: var(--danger);
+	}
+</style>

--- a/apps/website/src/components/events/emote-event.svelte
+++ b/apps/website/src/components/events/emote-event.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { EmoteEvent, User } from "$/gql/graphql";
+	import type { EmoteEvent, EmoteFlags, User } from "$/gql/graphql";
 	import {
 		ArrowsMerge,
 		Check,
@@ -17,151 +17,198 @@
 	import moment from "moment/min/moment-with-locales";
 	import FromNow from "$/components/from-now.svelte";
 	import { t } from "svelte-i18n";
+	import UserProfilePicture from "$/components/user-profile-picture.svelte";
+	import UserName from "$/components/user-name.svelte";
 
 	let { event }: { event: EmoteEvent } = $props();
+
+	// One semantic color per event, reused for both the icon and the left stripe,
+	// using the same theme variables already used for this purpose in the admin UI
+	// (--approve, --danger, --rename, --admin-merge, --admin-unlist).
+	function flagsColor(oldFlags: EmoteFlags, newFlags: EmoteFlags): string {
+		if (!oldFlags.publicListed && newFlags.publicListed) return "var(--approve)";
+		if (oldFlags.publicListed && !newFlags.publicListed) return "var(--danger)";
+		if (!oldFlags.approvedPersonal && newFlags.approvedPersonal) return "var(--approve)";
+		if (!oldFlags.deniedPersonal && newFlags.deniedPersonal) return "var(--danger)";
+		if (!oldFlags.defaultZeroWidth && newFlags.defaultZeroWidth) return "var(--rename)";
+		if (oldFlags.defaultZeroWidth && !newFlags.defaultZeroWidth) return "var(--rename)";
+		if (!oldFlags.private && newFlags.private) return "var(--admin-unlist)";
+		if (oldFlags.private && !newFlags.private) return "var(--approve)";
+		return "var(--primary)";
+	}
+
+	let color = $derived.by(() => {
+		switch (event.data.__typename) {
+			case "EventEmoteDataProcess":
+				switch (event.data.event) {
+					case "SUCCESS":
+						return "var(--approve)";
+					case "FAIL":
+						return "var(--danger)";
+					case "CANCEL":
+						return "var(--admin-unlist)";
+					case "START":
+						return "var(--admin-unlist)";
+					default:
+						return "var(--text-light)";
+				}
+			case "EventEmoteDataUpload":
+			case "EventEmoteDataChangeName":
+			case "EventEmoteDataChangeTags":
+				return "var(--rename)";
+			case "EventEmoteDataMerge":
+				return "var(--admin-merge)";
+			case "EventEmoteDataChangeFlags":
+				return flagsColor(event.data.oldFlags, event.data.newFlags);
+			case "EventEmoteDataDelete":
+				return "var(--danger)";
+			default:
+				return "var(--primary)";
+		}
+	});
 </script>
 
 {#snippet userLink(actor?: User | null, by: boolean = true)}
 	{#if actor && actor.mainConnection}
-		<a href="/users/{actor.id}" class="user-link" style:color={actor.highestRoleColor?.hex}
-			>{actor.mainConnection.platformDisplayName}</a
-		>
+		<a href="/users/{actor.id}" class="user-link">
+			<UserProfilePicture user={actor} size={24} />
+			<span class="username" style:color={actor.highestRoleColor?.hex}>
+				<UserName user={actor} />
+			</span>
+		</a>
 	{/if}
 {/snippet}
 
-<IconContext
-	values={{
-		style: "grid-area: icon; margin: 0 0.5rem;",
-		size: 1.2 * 16,
-		color: "var(--primary)",
-	}}
->
-	<div class="event">
-	{#if event.data.__typename === "EventEmoteDataUpload"}
-		<Plus />
-		<span class="text">
-			{$t("dialogs.emote-events.upload.action")}
-			{$t("words.by")}
-			{@render userLink(event.actor)}
-		</span>
-
-	{:else if event.data.__typename === "EventEmoteDataProcess"}
-		<Cpu />
-		{#if event.data.event === "START"}
-			<span class="text">{$t("dialogs.emote-events.process.start")}</span>
-		{:else if event.data.event === "SUCCESS"}
-			<span class="text">{$t("dialogs.emote-events.process.success")}</span>
-		{:else if event.data.event === "FAIL"}
-			<span class="text">{$t("dialogs.emote-events.process.fail")}</span>
-		{:else if event.data.event === "CANCEL"}
-			<span class="text">{$t("dialogs.emote-events.process.cancel")}</span>
+<IconContext values={{ style: "grid-area: icon; margin: 0 0.5rem;", size: 1.2 * 16, color }}>
+	<div class="event" style:border-left-color={color}>
+		{#if event.data.__typename === "EventEmoteDataUpload"}
+			<Plus />
+			<span class="text">
+				{$t("dialogs.emote-events.upload.action")}
+				{$t("words.by")}
+				{@render userLink(event.actor)}
+			</span>
+		{:else if event.data.__typename === "EventEmoteDataProcess"}
+			<Cpu />
+			{#if event.data.event === "START"}
+				<span class="text">{$t("dialogs.emote-events.process.start")}</span>
+			{:else if event.data.event === "SUCCESS"}
+				<span class="text">{$t("dialogs.emote-events.process.success")}</span>
+			{:else if event.data.event === "FAIL"}
+				<span class="text">{$t("dialogs.emote-events.process.fail")}</span>
+			{:else if event.data.event === "CANCEL"}
+				<span class="text">{$t("dialogs.emote-events.process.cancel")}</span>
+			{/if}
+		{:else if event.data.__typename === "EventEmoteDataChangeName"}
+			<NotePencil />
+			<span class="text">
+				{$t("dialogs.emote-events.change_name.action")}
+				{$t("words.from")}
+				{event.data.oldName}
+				{$t("words.to")}
+				{event.data.newName}
+				{$t("words.by")}
+				{@render userLink(event.actor)}
+			</span>
+		{:else if event.data.__typename === "EventEmoteDataMerge"}
+			<ArrowsMerge />
+			<span class="text">
+				{$t("dialogs.emote-events.merge.action")}
+				{$t("words.with")}
+				<a href="/emotes/{event.data.newEmote.id}">{event.data.newEmote.defaultName}</a>
+				{$t("words.by")}
+				{@render userLink(event.actor)}
+			</span>
+		{:else if event.data.__typename === "EventEmoteDataChangeOwner"}
+			<Users />
+			<span class="text">
+				{$t("dialogs.emote-events.change_owner.action")}
+				{$t("words.from")}
+				{@render userLink(event.data.oldOwner, false)}
+				{$t("words.to")}
+				{@render userLink(event.data.newOwner, false)}
+				{$t("words.by")}
+				{@render userLink(event.actor)}
+			</span>
+		{:else if event.data.__typename === "EventEmoteDataChangeTags"}
+			<NotePencil />
+			<span class="text">
+				{$t("dialogs.emote-events.change_tags.action")}
+				{event.data.newTags}
+				{$t("words.by")}
+				{@render userLink(event.actor)}
+			</span>
+		{:else if event.data.__typename === "EventEmoteDataChangeFlags"}
+			{#if !event.data.oldFlags.publicListed && event.data.newFlags.publicListed}
+				<Check />
+				<span class="text">
+					{$t("dialogs.emote-events.change_flags.approved_public.action")}
+					{$t("words.by")}
+					{@render userLink(event.actor)}
+				</span>
+			{:else if event.data.oldFlags.publicListed && !event.data.newFlags.publicListed}
+				<X />
+				<span class="text">
+					{$t("dialogs.emote-events.change_flags.removed_public.action")}
+					{$t("words.by")}
+					{@render userLink(event.actor)}
+				</span>
+			{:else if !event.data.oldFlags.approvedPersonal && event.data.newFlags.approvedPersonal}
+				<Check />
+				<span class="text">
+					{$t("dialogs.emote-events.change_flags.approved_personal.action")}
+					{$t("words.by")}
+					{@render userLink(event.actor)}
+				</span>
+			{:else if !event.data.oldFlags.deniedPersonal && event.data.newFlags.deniedPersonal}
+				<X />
+				<span class="text">
+					{$t("dialogs.emote-events.change_flags.rejected_personal.action")}
+					{$t("words.by")}
+					{@render userLink(event.actor)}
+				</span>
+			{:else if !event.data.oldFlags.defaultZeroWidth && event.data.newFlags.defaultZeroWidth}
+				<StackSimple />
+				<span class="text">
+					{$t("dialogs.emote-events.change_flags.added_overlaying.action")}
+					{$t("words.by")}
+					{@render userLink(event.actor)}
+				</span>
+			{:else if event.data.oldFlags.defaultZeroWidth && !event.data.newFlags.defaultZeroWidth}
+				<StackSimple />
+				<span class="text">
+					{$t("dialogs.emote-events.change_flags.removed_overlaying.action")}
+					{$t("words.by")}
+					{@render userLink(event.actor)}
+				</span>
+			{:else if !event.data.oldFlags.private && event.data.newFlags.private}
+				<LockSimple />
+				<span class="text">
+					{$t("dialogs.emote-events.change_flags.added_private.action")}
+					{$t("words.by")}
+					{@render userLink(event.actor)}
+				</span>
+			{:else if event.data.oldFlags.private && !event.data.newFlags.private}
+				<LockSimpleOpen />
+				<span class="text">
+					{$t("dialogs.emote-events.change_flags.removed_private.action")}
+					{$t("words.by")}
+					{@render userLink(event.actor)}
+				</span>
+			{/if}
+		{:else if event.data.__typename === "EventEmoteDataDelete"}
+			<Trash />
+			<span class="text">
+				{$t("dialogs.emote-events.delete.action")}
+				{$t("words.by")}
+				{@render userLink(event.actor)}
+			</span>
 		{/if}
 
-	{:else if event.data.__typename === "EventEmoteDataChangeName"}
-		<NotePencil />
-		<span class="text">
-			{$t("dialogs.emote-events.change_name.action")}
-			{$t("words.from")} {event.data.oldName}
-			{$t("words.to")} {event.data.newName}
-			{$t("words.by")} {@render userLink(event.actor)}
+		<span class="time">
+			<FromNow date={moment(event.createdAt)} showExact />
 		</span>
-
-	{:else if event.data.__typename === "EventEmoteDataMerge"}
-		<ArrowsMerge />
-		<span class="text">
-			{$t("dialogs.emote-events.merge.action")}
-			{$t("words.with")} <a href="/emotes/{event.data.newEmote.id}">{event.data.newEmote.defaultName}</a>
-			{$t("words.by")} {@render userLink(event.actor)}
-		</span>
-
-	{:else if event.data.__typename === "EventEmoteDataChangeOwner"}
-		<Users />
-		<span class="text">
-			{$t("dialogs.emote-events.change_owner.action")}
-			{$t("words.from")} {@render userLink(event.data.oldOwner, false)}
-			{$t("words.to")} {@render userLink(event.data.newOwner, false)}
-			{$t("words.by")} {@render userLink(event.actor)}
-		</span>
-
-	{:else if event.data.__typename === "EventEmoteDataChangeTags"}
-		<NotePencil />
-		<span class="text">
-			{$t("dialogs.emote-events.change_tags.action")} {event.data.newTags}
-			{$t("words.by")} {@render userLink(event.actor)}
-		</span>
-
-	{:else if event.data.__typename === "EventEmoteDataChangeFlags"}
-		{#if !event.data.oldFlags.publicListed && event.data.newFlags.publicListed}
-			<Check />
-			<span class="text">
-				{$t("dialogs.emote-events.change_flags.approved_public.action")}
-				{$t("words.by")} {@render userLink(event.actor)}
-			</span>
-
-		{:else if event.data.oldFlags.publicListed && !event.data.newFlags.publicListed}
-			<X />
-			<span class="text">
-				{$t("dialogs.emote-events.change_flags.removed_public.action")}
-				{$t("words.by")} {@render userLink(event.actor)}
-			</span>
-
-		{:else if !event.data.oldFlags.approvedPersonal && event.data.newFlags.approvedPersonal}
-			<Check />
-			<span class="text">
-				{$t("dialogs.emote-events.change_flags.approved_personal.action")}
-				{$t("words.by")} {@render userLink(event.actor)}
-			</span>
-
-		{:else if !event.data.oldFlags.deniedPersonal && event.data.newFlags.deniedPersonal}
-			<X />
-			<span class="text">
-				{$t("dialogs.emote-events.change_flags.rejected_personal.action")}
-				{$t("words.by")} {@render userLink(event.actor)}
-			</span>
-
-		{:else if !event.data.oldFlags.defaultZeroWidth && event.data.newFlags.defaultZeroWidth}
-			<StackSimple />
-			<span class="text">
-				{$t("dialogs.emote-events.change_flags.added_overlaying.action")}
-				{$t("words.by")} {@render userLink(event.actor)}
-			</span>
-
-		{:else if event.data.oldFlags.defaultZeroWidth && !event.data.newFlags.defaultZeroWidth}
-			<StackSimple />
-			<span class="text">
-				{$t("dialogs.emote-events.change_flags.removed_overlaying.action")}
-				{$t("words.by")} {@render userLink(event.actor)}
-			</span>
-
-		{:else if !event.data.oldFlags.private && event.data.newFlags.private}
-			<LockSimple />
-			<span class="text">
-				{$t("dialogs.emote-events.change_flags.added_private.action")}
-				{$t("words.by")} {@render userLink(event.actor)}
-			</span>
-
-		{:else if event.data.oldFlags.private && !event.data.newFlags.private}
-			<LockSimpleOpen />
-			<span class="text">
-				{$t("dialogs.emote-events.change_flags.removed_private.action")}
-				{$t("words.by")} {@render userLink(event.actor)}
-			</span>
-		{/if}
-
-	{:else if event.data.__typename === "EventEmoteDataDelete"}
-		<Trash />
-		<span class="text">
-			{$t("dialogs.emote-events.delete.action")}
-			{$t("words.by")}
-			{@render userLink(event.actor)}
-		</span>
-	{/if}
-
-	<span class="time">
-		<FromNow date={moment(event.createdAt)} />
-	</span>
-</div>
-
+	</div>
 </IconContext>
 
 <style lang="scss">
@@ -171,7 +218,10 @@
 		justify-content: start;
 		align-items: center;
 		row-gap: 0.5rem;
-		margin: 1rem 0;
+		margin: 0.75rem 0;
+		padding-left: 0.75rem;
+
+		border-left: 3px solid transparent;
 
 		font-size: 0.75rem;
 		font-weight: 500;
@@ -181,7 +231,21 @@
 		}
 
 		.user-link {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.35rem;
+			vertical-align: middle;
 			color: var(--text);
+			text-decoration: none;
+
+			&:hover .username,
+			&:focus-visible .username {
+				text-decoration: underline;
+			}
+		}
+
+		.username {
+			font-weight: 600;
 		}
 
 		.time {

--- a/apps/website/src/components/from-now.svelte
+++ b/apps/website/src/components/from-now.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Moment } from "moment/min/moment-with-locales";
 
-	let { date }: { date: Moment } = $props();
+	let { date, showExact = false }: { date: Moment; showExact?: boolean } = $props();
 </script>
 
-<span title={date.format("lll")}>{date.fromNow()}</span>
+<span title={date.format("lll")}>{date.fromNow()}{showExact ? ` (${date.format("ll")})` : ""}</span>

--- a/apps/website/src/components/layout/emote-tabs.svelte
+++ b/apps/website/src/components/layout/emote-tabs.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { numberFormat } from "$/lib/utils";
 	import TabLink from "../tab-link.svelte";
-	import { Users, Pulse } from "phosphor-svelte";
+	import { Users, Pulse, Info } from "phosphor-svelte";
 	import { t } from "svelte-i18n";
 
 	let { id, channelCount }: { id: string; channelCount?: number } = $props();
@@ -23,6 +23,12 @@
 		<Pulse />
 		{#snippet active()}
 			<Pulse weight="fill" />
+		{/snippet}
+	</TabLink>
+	<TabLink title={$t("common.info")} href="/emotes/{id}/info" responsive>
+		<Info />
+		{#snippet active()}
+			<Info weight="fill" />
 		{/snippet}
 	</TabLink>
 	<!-- <TabLink title={$t("common.statistics")} href="/emotes/{id}/statistics" responsive>

--- a/apps/website/src/lib/utils.ts
+++ b/apps/website/src/lib/utils.ts
@@ -21,6 +21,32 @@ export function numberFormat() {
 	});
 }
 
+export function exactNumberFormat() {
+	return getNumberFormatter();
+}
+
+/**
+ * Formats a byte count into a human readable string, e.g. 152400 -> "149KB".
+ */
+export function formatBytes(bytes: number): string {
+	if (!Number.isFinite(bytes) || bytes < 0) {
+		return "0B";
+	}
+
+	const units = ["B", "KB", "MB", "GB"];
+	let value = bytes;
+	let unitIndex = 0;
+
+	while (value >= 1024 && unitIndex < units.length - 1) {
+		value /= 1024;
+		unitIndex++;
+	}
+
+	const decimals = unitIndex === 0 || value >= 100 ? 0 : value >= 10 ? 1 : 2;
+
+	return `${value.toFixed(decimals)}${units[unitIndex]}`;
+}
+
 export function isMobileLayout(): boolean {
 	return window.matchMedia("screen and (max-width: 960px)").matches;
 }

--- a/apps/website/src/locales/de.json
+++ b/apps/website/src/locales/de.json
@@ -907,11 +907,13 @@
 				"used_by_channels": "Kanäle, die dieses Emote nutzen",
 				"channels_tooltip": "Anzahl der Kanäle, die dieses Emote aktuell in einem ihrer Emote-Sets aktiv gesetzt haben.",
 				"trending_this_week": "Trending-Rang diese Woche",
-				"trending_tooltip": "Position unter den Top ~500 Emotes von 7TV nach aktuellem Wachstum.",
+				"trending_tooltip": "Live-Position nach aktuellem Wachstum unter den Top 500 Emotes.",
 				"top_all_time": "Top-Rang aller Zeiten",
-				"top_all_time_tooltip": "Position unter den Top ~500 Emotes von 7TV nach gesamter Netto-Kanalverbreitung.",
+				"top_all_time_tooltip": "Live-Position nach gesamter Netto-Kanalverbreitung unter den Top 500 Emotes.",
 				"not_ranked": "Aktuell nicht gerankt",
-				"raw_score": "Wachstums-Score: {score}",
+				"trending_list_empty": "Keine Emotes gefunden.",
+				"trending_list_error": "Liste konnte nicht geladen werden.",
+				"trending_list_load_more": "Mehr laden",
 				"stats_error": "Kanal-/Ranking-Statistiken konnten nicht geladen werden.",
 				"usage_note": "7TV erfasst nicht, wie oft ein Emote tatsächlich im Chat gesendet wird. Die Zahlen oben zeigen, wie viele Kanäle dieses Emote hinzugefügt haben und wie es in den Trending-/Top-Listen von 7TV abschneidet."
 			}

--- a/apps/website/src/locales/de.json
+++ b/apps/website/src/locales/de.json
@@ -1,1027 +1,1040 @@
 {
-  "page_titles": {
-    "suffix": "7TV",
-    "admin_suffix": "7TV Admin",
-    "trending_emotes": "Angesagte Emotes",
-    "top_emotes": "Top Emotes",
-    "global_emotes": "Globale Emotes",
-    "new_emotes": "Neue Emotes",
-    "bookmarked_emotes": "Gespeicherte Emotes",
-    "bookmarked_emote_sets": "Gespeicherte Emote Sets",
-    "bookmarked_users": "Gespeicherte Benutzer",
-    "account_settings": "Kontoeinstellungen",
-    "editor_settings": "Editor Einstellungen",
-    "notification_settings": "Benachrichtigungseinstellungen",
-    "blocked_settings": "Blockierte Einstellungen",
-    "billing_settings": "Abrechnungseinstellungen",
-    "admin_emote_public_listing": "Emote-Anfragen zur öffentlichen Nutzung",
-    "admin_emote_personal_use": "Emote-Anfragen zur persönlichen Nutzung",
-    "admin_emote_resolved": "Erledigte Emote Tickets"
-  },
-  "page_errors": {
-    "not_found": "Die Seite, nach der du suchst, konnte nicht gefunden werden.",
-    "forbidden": "Du hast nicht die Berechtigung, diese Seite zu sehen.",
-    "unauthorized": "Du bist nicht autorisiert, diese Seite zu sehen.",
-    "unexpected": "Du kannst probieren, die Seite neu zu laden. Wenn das Problem besteht, kontaktiere uns bitte.",
-    "generic": "Ein Fehler ist aufgetreten.",
-    "emote_set_load": "Ein Fehler ist beim Laden des Emote Set aufgetreten",
-    "emote_set_not_found": "Emote Set nicht gefunden",
-    "user": "Nutzer konnte nicht geladen werden"
-  },
-  "words": {
-    "from": "von",
-    "to": "zu",
-    "with": "mit",
-    "by": "von"
-  },
-  "common": {
-    "sign_in": "Anmelden",
-    "sign_out": "Abmelden",
-    "go_back": "Zurück",
-    "super_admin": "Super Admin",
-    "skip_to_content": "Zum Inhalt springen",
-    "emotes": "{count, plural, one {Emote} other {Emotes}}",
-    "emote_sets": "{count, plural, one {Emote Set} other {Emote Sets}}",
-    "users": "{count, plural, one {Nutzer} other {Nutzer}}",
-    "channels": "{count, plural, one {Kanal} other {Kanäle}}",
-    "followers": "{count, plural, one {Follower} other {Follower}}",
-    "items": "{count, plural, one {Gegenstand} other {Gegenstände}}",
-    "subscriptions": "{count, plural, one {Abonnement} other {Abonnements}}",
-    "payment_methods": "{count, plural, one {Zahlungsmethode} other {Zahlungsmethoden}}",
-    "date": "Datum",
-    "help": "Hilfe",
-    "for": "für",
-    "error": "Fehler",
-    "loading": "Lädt...",
-    "paint_bundles": "Paint Bundles",
-    "notifications": "Benachrichtigungen",
-    "connections": "Verknüpfungen",
-    "direct_messages": "Direktnachrichten",
-    "mod_comments": "Mod Kommentare",
-    "profile_picture": "Profilbild",
-    "suggested_emotes": "Vorgeschlagene Emotes",
-    "personal_emotes": "Persönliche Emotes",
-    "no_more_emotes": "Keine Emotes mehr",
-    "no_emotes": "Keine Emotes",
-    "your_subscription": "Dein Abonnement",
-    "theme": "Design",
-    "language": "Sprache",
-    "developer_portal": "Entwicklerportal",
-    "faq": "Häufig gestellte Fragen",
-    "faq_short": "FAQ",
-    "privacy": "Datenschutzrichtlinien",
-    "tos": "Nutzungsbedingungen",
-    "trending": "Im Trend",
-    "top": "Top",
-    "global": "Global",
-    "new": "Neu",
-    "Weekly": "Wöchentlich",
-    "Monthly": "Monatlich",
-    "Today": "Heute",
-    "news": "Neuigkeiten",
-    "Default_set": "Standard Set",
-    "following": "Folgt",
-    "activity": "Aktivität",
-    "analytics": "Analysen",
-    "statistics": "Statistiken",
-    "contact": "Kontakt",
-    "cosmetics": "Cosmetics",
-    "editors": "Editoren",
-    "active": "Aktiv",
-    "profile": "Profil",
-    "pinned": "Angeheftet",
-    "settings": "Einstellungen",
-    "delete_account": "Konto löschen"
-  },
-  "labels": {
-    "enter_text": "Text eingeben",
-    "redeem": "Code eingeben",
-    "search": "Suche",
-    "refetch": "Erneut abrufen",
-    "manage_connections": "Verknüpfungen verwalten",
-    "manage_editors": "Editoren verwalten",
-    "none": "Keine",
-    "search_user": "Benutzer suchen",
-    "search_country": "Land suchen",
-    "search_emote_set": "Emote Set suchen",
-    "search_users": "{count, plural, one {Benutzer suchen} other {Benutzer suchen}}",
-    "tags": "Tags",
-    "close": "Schließen",
-    "contribute": "Beitragen",
-    "enter_tags": "Tags eingeben",
-    "tag_limit_reached": "Tag Limit von {limit} erreicht",
-    "filters": "Filter",
-    "no_filters": "Keine Filter",
-    "emote_name": "Emote Name",
-    "copy_link": "Link kopieren",
-    "create_emote_set": "Erstelle ein neues Set",
-    "emote_set_name": "Emote Set Name",
-    "emote_attribution": "Emote Zuweisung",
-    "select": "Auswählen",
-    "selection_mode": "Auswahlmodus",
-    "edit": "Bearbeiten",
-    "capacity": "Kapazität",
-    "enable": "Aktivieren",
-    "disable": "Deaktivieren",
-    "disabled": "Deaktiviert",
-    "more": "Mehr",
-    "actions": "Aktionen",
-    "download": "Herunterladen",
-    "report": "Melden",
-    "delete": "Löschen",
-    "time_select": {
-      "week": "Diese Woche",
-      "month": "Diesen Monat",
-      "year": "Dieses Jahr"
-    },
-    "gift": "Verschenken",
-    "follow": "Folgen",
-    "connect": "Verbinden",
-    "disconnect": "Trennen",
-    "email": "E-Mail",
-    "password": "Passwort",
-    "all": "Alles",
-    "other": "Anderes",
-    "cancel": "Abbrechen",
-    "confirm": "Bestätigen",
-    "proceed": "Fortfahren",
-    "save": "Speichern",
-    "remove": "Entfernen",
-    "accept": "Akzeptieren",
-    "deny": "Ablehnen",
-    "enter": "Bestätigen"
-  },
-  "themes": {
-    "system": "System",
-    "dark": "Dunkel",
-    "light": "Hell"
-  },
-  "flags": {
-    "global": "Global",
-    "trending": "Im Trend",
-    "overlaying": "Überlagernd",
-    "default": "Standard",
-    "personal": "Persönlich",
-    "listed": "Gelistet",
-    "unlisted": "Ungelistet",
-    "personal_use": "Persönliche Nutzung",
-    "deleted": "Gelöscht",
-    "private": "Privat",
-    "personal_use_approved": "Persönliche Nutzung freigegeben",
-    "personal_use_denied": "Persönliche Nutzung abgelehnt",
-    "personal_use_pending": "Überprüfung zur persönlichen Nutzung ausstehend",
-    "renamed": "Umbenannt",
-    "nsfw": "NSFW",
-    "editor_flags": {
-      "pending": "Ausstehend",
-      "accepted": "Akzeptiert",
-      "rejected": "Abgelehnt",
-      "you_accepted": "Von dir akzeptiert",
-      "you_rejected": "Von dir abgelehnt"
-    }
-  },
-  "notifications": {
-    "system": "System",
-    "approved_for_public": "Dein Emote {emote} wurde zur öffentlichen Listung freigegeben."
-  },
-  "sub_info": {
-    "plan": "Abonnement",
-    "free": "Kostenlos",
-    "gifted_by": "Geschenkt von",
-    "ends": "Abo endet",
-    "total": "Gesamt",
-    "credits": "Abo-Credits"
-  },
-  "file_limits": {
-    "max_size": "{size} maximale Dateigröße",
-    "max_resolution": "{width}x{height} maximale Auflösung",
-    "max_frames": "{count} maximale Frames",
-    "resolution_error": "Die Auflösung darf {width}x{height} nicht überschreiten",
-    "duration_error": "Die Dauer muss {duration} Sekunden oder weniger betragen"
-  },
-  "dialogs": {
-    "sign_in": {
-      "title": "Bei 7TV anmelden",
-      "subtitle": "Melde dich an oder erstelle ein Konto, um fortzufahren",
-      "continue_with": "Fortfahren mit {platform}",
-      "trouble": "Schwierigkeiten bei der Anmeldung?",
-      "legal_yapping": "Durch das Anmelden stimmst du unseren",
-      "and": "und",
-      "linking_new": "Du hast bereits ein 7TV-Konto und möchtest eine neue Verbindung hinzufügen? Meld dich mit deiner bestehenden Verbindung an und verknüpfe die neue in den",
-      "settings": "Einstellungen"
-    },
-    "search": {
-      "emotes": "Emotes",
-      "users": "Benutzer"
-    },
-    "upload": {
-      "title": "Emote hochladen",
-      "untitled": "Unbetitelt",
-      "chat": "Sende eine Nachricht",
-      "drag_drop": "Drag & Drop um hochzuladen, oder",
-      "browse_files": "Dateien durchsuchen",
-      "accept_rules": "Ich akzeptiere die Regeln und Richtlinien",
-      "discard": "Verwerfen",
-      "upload_guidelines": "Emote Upload Richtlinien",
-      "upload": "Hochladen"
-    },
-    "emote_set": {
-      "title": "Aktives Emote Set",
-      "create": "Erstelle ein Emote Set",
-      "name": "Emote Set Name",
-      "label": "Name",
-      "confirm": "Erstellen",
-      "copy_set": "Set kopieren",
-      "special": "Spezial",
-      "favourite_sets": {
-        "title": "Favorisierte Emote Sets",
-        "add": "Hinzufügen und umbenennen für alle",
-        "remove": "Aus allen entfernen"
-      },
-      "mass_select_feature": {
-        "add": "Zu Emote Set hinzufügen",
-        "remove": "Aus Emote Set entfernen",
-        "amount_selected_label": "/20 Ausgewählt"
-      },
-      "default_emote_set": {
-        "remove": "Emote aus {set} entfernen",
-        "add": "Emote zu {set} hinzufügen",
-        "conflicting_name": "Namenskonflikt"
-      }
-    },
-    "manage_aliases": {
-      "title": "Emote Aliase verwalten",
-      "add_placeholder": "Neuen Alias hinzufügen.."
-    },
-    "rename_emote": {
-      "title": "Emote in {set} umbenennen",
-      "input_placeholder": "Neuer Emote Name",
-      "confirmation_message": "Möchtest du dieses Emote in {set} wirklich umbenennen?",
-      "confirm": "Umbenennen"
-    },
-    "remove_emote_from_set": {
-      "title": "Emote aus {set} entfernen",
-      "warning_message": "Möchtest du {emote} wirklich aus {set} entfernen?",
-      "confirm": "Entfernen"
-    },
-    "add_emote": {
-      "title": "Füge {emote} hinzu zu",
-      "change_name": "Emote Namen ändern",
-      "confirm": "Bestätigen",
-      "confirm_changes": "{count, plural, one {1 Änderung bestätigen} other {{count} Änderungen bestätigen}}"
-    },
-    "emote_ticket": {
-      "emote_queue": "Emote Warteschlange",
-      "activity": "Aktivität",
-      "comments": "Kommentare"
-    },
-    "emote_context_menu": {
-      "add_remove_emote": "Emote hinzufügen/entfernen",
-      "edit_emote_alias": "Emote Alias bearbeiten",
-      "remove_emote": "Emote aus Set entfernen",
-      "open_in_new_tab": "In neuem Tab öffnen",
-      "copy_emote_link": "Emote Link kopieren"
-    },
-    "cart": {
-      "title": "Dein Warenkorb",
-      "duration": "Dauer",
-      "price": "Preis",
-      "preview": "Vorschau",
-      "purchase_as_gift": "Als Geschenk kaufen",
-      "total": "Gesamt"
-    },
-    "editor": {
-      "permissions": "Editor Berechtigungen festlegen",
-      "super_admin": "Super Admin",
-      "emote_sets": "Emote Sets",
-      "admin": "Admin",
-      "emotes": "Emotes",
-      "user": "Benutzer",
-      "manage_personal_emotes": "Persönliche Emote Sets verwalten",
-      "confirm": "Bestätigen",
-      "no_editors": "Keine Editoren zum Anzeigen",
-      "permissions_details": {
-        "manage": "Verwalten",
-        "create": "Erstellen",
-        "transfer": "Übertragen",
-        "manage_profile": "Profil verwalten",
-        "manage_emotes": "Emotes verwalten",
-        "manage_billing": "Zahlungen verwalten",
-        "manage_editors": "Editoren verwalten",
-        "view_billing": "Zahlungsinformationen ansehen"
-      }
-    },
-    "emote_info": {
-      "processing": "Dieses Emote wird noch verarbeitet",
-      "refresh": "Aktualisieren",
-      "download": "Herunterladen"
-    },
-    "copy_emotes": {
-      "title": "Kopiere ausgewählte Emotes nach"
-    },
-    "default_set": {
-      "title": "Standard Emote Set"
-    },
-    "delete_account": {
-      "warning": "Warnung",
-      "warning_message": "Durch diese Aktion wird dein Konto endgültig gelöscht. Du kannst diese Aktion nicht rückgängig machen.",
-      "choose_reasons": "Wähle die Gründe für die Löschung des Kontos",
-      "reasons": {
-        "no_longer_use": "Ich benutze 7TV nicht mehr",
-        "privacy_concerns": "Bedenken hinsichtlich des Datenschutzes",
-        "not_useful": "Nicht hilfreich",
-        "other": "Andere"
-      },
-      "confirm_username": "Gib deinen Nutzernamen zur Bestätigung ein"
-    },
-    "delete_emote_or_set": {
-      "title": "Lösche {name}",
-      "warning_message_emote": "Durch diese Aktion wird dein Emote endgültig gelöscht. Du kannst diese Aktion nicht rückgängig machen.",
-      "warning_message_set": "Durch diese Aktion wird dein Emote Set endgültig gelöscht. Du kannst diese Aktion nicht rückgängig machen.",
-      "reason": "Grund",
-      "reason_for_deletion": "Grund des Löschens"
-    },
-    "edit_emote": {
-      "title": "Bearbeite {emote}"
-    },
-    "edit_emote_set": {
-      "title": "Emote Set bearbeiten",
-      "show_on_profile": "Im Profil anzeigen",
-      "publicly_listed": "Öffentlich gelistet"
-    },
-    "remove_emote": {
-      "title": "Ausgewählte Emotes aus {set} entfernen"
-    },
-    "report_emote": {
-      "title": "Emote melden",
-      "choose_reasons": "Wähle den Grund",
-      "reasons": {
-        "my_work": "Ich habe dieses Emote erstellt, aber es wurde von jemand anderem hochgeladen",
-        "duplicate": "Dieses Emote ist ein Duplikat",
-        "sexual": "Dieses Emote enthält pornografische oder übermäßig sexualisierte Darstellungen",
-        "violance": "Dieses Emote zeigt extreme Gewalt oder Blut",
-        "its_me": "Dieses Emote stellt mich dar, und ich möchte das nicht",
-        "offensive": "Ich finde dieses Emote anstößig",
-        "other": "Anderes"
-      },
-      "additional_info": "Zusätzliche Informationen",
-      "disclaimer": "Ein Missbrauch der Meldefunktion kann einen Entzug deines Zugangs zur Folge haben."
-    },
-    "transfer_emote": {
-      "title": "Übertrage {emote}",
-      "details": "Dadurch wird {emote} übertragen.",
-      "receipient": "Emote Empfänger",
-      "transfer": "Übertragen"
-    },
-    "badge": {
-      "title": "Abzeichen"
-    },
-    "subscription": {
-      "gifted_by": "Dein Abonnement wurde dir geschenkt von",
-      "cancel_notice": "Wenn du dein Abonnement jetzt kündigst, verlierst du sofort den Zugang zu deinen Abonnementvorteilen. Möchtest du dein Abonnement wirklich kündigen?",
-      "cancel_confirmation": "Möchtest du dein Abonnement wirklich kündigen? Am Ende deines aktuellen Abrechnungszeitraums verlierst du den Zugang zu deinen Abonnementvorteilen.",
-      "confirm": "Bestätigen"
-    },
-    "error": {
-      "title": "Error"
-    },
-    "pickems": {
-      "gift": {
-        "title": "Verschenke den Pick'ems Pass",
-        "gift_to": "Verschenke einen Pick-Ems-Pass an",
-        "recipient": "Empfänger auswählen",
-        "back": "Zurück",
-        "continue": "Fortfahren"
-      }
-    },
-    "gift": {
-      "title": "Verschenke 1",
-      "gift_to": "Verschenke 1 {variant} an",
-      "recipient": "Wähle einen Empfänger aus"
-    },
-    "paint": {
-      "title": "Paint"
-    },
-    "buttons": {
-      "back": "Zurück",
-      "continue": "Weiter"
-    },
-    "emote-events": {
-      "upload": {
-        "action": "Hochgeladen"
-      },
-      "process": {
-        "start": "Neue Verarbeitung gestartet",
-        "success": "Verarbeitung erfolgreich abgeschlossen",
-        "fail": "Verarbeitung fehlgeschlagen",
-        "cancel": "Verarbeitung abgebrochen"
-      },
-      "change_name": {
-        "action": "Umbenannt"
-      },
-      "merge": {
-        "action": "Zusammengefügt"
-      },
-      "change_owner": {
-        "action": "Eigentumsrechte wurden übertragen"
-      },
-      "change_tags": {
-        "action": "Tags gesetzt auf"
-      },
-      "change_flags": {
-        "approved_public": {
-          "action": "Für die öffentliche Listung freigegeben"
-        },
-        "removed_public": {
-          "action": "Aus der öffentlichen Listung entfernt"
-        },
-        "approved_personal": {
-          "action": "Persönliche Nutzung freigegeben"
-        },
-        "rejected_personal": {
-          "action": "Für persönliche Nutzung abgelehnt"
-        },
-        "added_overlaying": {
-          "action": "Die Überlagerungsmarkierung wurde hinzugefügt"
-        },
-        "removed_overlaying": {
-          "action": "Die Überlagerungsmarkierung wurde entfernt"
-        },
-        "added_private": {
-          "action": "Private Markierung hinzugefügt"
-        },
-        "removed_private": {
-          "action": "Private Markierung entfernt"
-        }
-      },
-      "delete": {
-        "action": "Gelöscht"
-      }
-    }
-  },
-  "pages": {
-    "activity": {
-      "title": "Aktivität",
-      "emote": {
-        "deleted_emote": "Gelöschtes Emote",
-        "deleted_set": "Gelöschtes Set",
-        "by": "von",
-        "created": "Erstellt",
-        "changed_tags": "Tags geändert für",
-        "changed_capacity": "Kapazität geändert für",
-        "added": "Hinzugefügt",
-        "removed": "Emote entfernt",
-        "renamed": "Umbenanntes Emote",
-        "in": "in",
-        "from": "von",
-        "to": "zu",
-        "deleted": "Gelöscht"
-      },
-      "user": {
-        "changed_paint": "Aktive Paint geändert von",
-        "changed_badge": "Aktives Abzeichen geändert von",
-        "removed": "Entfernt",
-        "connection": "Verknüpfungen",
-        "changed_set": "Aktives Emote Set geändert von",
-        "added": "Hinzugefügt",
-        "no_badge": "Kein Abzeichen",
-        "no_paint": "Keine Paint",
-        "deleted": "Gelöscht"
-      }
-    },
-    "auth": {
-      "title": {
-        "logging": "Anmeldung läuft...",
-        "logged": "Angemeldet",
-        "failed": "Fehler beim Anmelden"
-      },
-      "state": {
-        "logging": "Anmeldung läuft...",
-        "logged": "Angemeldet",
-        "failed": {
-          "title": "Anmeldung fehlgeschlagen",
-          "message": "Stelle sicher, dass du dieses Fenster über die Erweiterung öffnest"
-        }
-      }
-    },
-    "home": {
-      "title": "Start",
-      "features": {
-        "emote_slots": "1000 Emote Slots",
-        "emote_slots_info": "Jeder erhält 1000 personalisierbare Emote Slots pro Kanal, und das kostenlos. Bringe all deine Emotes an einem Ort unter.",
-        "emote_slots_button": "Emotes durchsuchen",
-        "emote_sets": "Emote Sets",
-        "emote_sets_info": "Gruppiere Emotes in anpassbare Sets, die mit anderen Nutzern geteilt oder schnell auf deinem Kanal ausgetauscht werden können.",
-        "emote_sets_button": "Erstelle ein Emote Set",
-        "custom_emotes": "Benutzerdefinierte Emote Namen",
-        "custom_emotes_info": "Magst Du den Namen eines Emotes nicht, den der Autor vergeben hat? Kein Problem, Du kannst den Namen für Deinen eigenen Kanal anpassen.",
-        "custom_emotes_button": "Emotes durchsuchen",
-        "real-time": "Echtzeit Aktualisierungen",
-        "real-time_info": "Das Ändern von Emotes in deinem Kanal erfolgt sofort für alle Zuschauer. Kein F5 mehr nötig, kein Warten mehr.",
-        "real-time_button": "Lade die Erweiterung herunter",
-        "large_community": "Große Community",
-        "large_community_info": "7TV bietet mehr als 2.000.000 tägliche Nutzer und verfügt über eine Bibliothek mit über 1.000.000 öffentlichen Emotes.",
-        "large_community_button": "Tritt unserem Discord bei",
-        "next_gen": "Next-gen Formate",
-        "next_gen_info": "Wir verwenden neuere, stärker optimierte Bildformate wie WebP und AVIF, um die Bandbreitennutzung zu reduzieren.",
-        "next_gen_button": "Lade die Erweiterung herunter"
-      }
-    },
-    "help": {
-      "title": "Hilfe"
-    },
-    "directory": {
-      "title": "Verzeichnis",
-      "bookmarked": "Mit Lesezeichen versehen",
-      "sorting": {
-        "title": "Sortierung",
-        "alphabetical": "Alphabetisch",
-        "upload_date": "Upload-Datum"
-      },
-      "filters": {
-        "animated": "Animiert",
-        "static": "Statisch",
-        "overlaying": "Überlagernd",
-        "personal_use": "Persönliche Nutzung",
-        "exact_match": "Genaue Übereinstimmung"
-      },
-      "size": {
-        "title": "Größe",
-        "any": "Jede Größe"
-      }
-    },
-    "landing": {
-      "start": "Beginne deine Reise mit Hunderten von Emotes und Funktionen, die dein Chat-Erlebnis verbessern. Lade die offizielle 7TV-Erweiterung oder andere Tools von Drittanbietern herunter.",
-      "developers": {
-        "header": "Quellcode verfügbar",
-        "info": "Unsere gesamte Codebasis ist auf GitHub unter einer Quelloffenen Lizenz verfügbar. Jeder kann diese einsehen und zu ihr beitragen."
-      },
-      "download": {
-        "start": "Beginne deine Reise mit Hunderten von Emotes und Funktionen, die dein Chat-Erlebnis verbessern. Lade die offizielle 7TV-Erweiterung oder andere Tools von Drittanbietern herunter.",
-        "extension": "Browser Erweiterung",
-        "stable": "Stabile Version",
-        "nightly": "Nightly Version",
-        "chatterino": "Chatterino",
-        "mobile": {
-          "apps": "Mobile Apps"
-        },
-        "bots": {
-          "header": "Chat Bots"
-        }
-      },
-      "features": {
-        "header": "Warum 7TV?",
-        "info": "Unsere Plattform bietet eine Vielzahl nützlicher Funktionen, die dein Chat-Erlebnis verbessern werden."
-      },
-      "footer": {
-        "affiliated": "7TV gehört nicht zu Twitch, Kick, YouTube oder Discord",
-        "privacy_policy": "Datenschutzerklärung",
-        "tos": "Nutzungsbedingungen"
-      },
-      "hero": {
-        "platform": "Die Emote Plattform",
-        "all": "für alle",
-        "download": "Herunterladen",
-        "manage": "Verwalte hunderte von Emotes für deinen Twitch-, Kick- oder YouTube-Kanal. Verbessere dein Chat-Erlebnis.",
-        "more": "Mehr erfahren",
-        "xmas": {
-          "header": "Weihnachts-Abo-Aktion",
-          "info": "Verschenke dieses Weihnachten 1 Abo an jemanden und erhalte ein besonderes Abzeichen!",
-          "gift": "Abo verschenken"
-        },
-        "nnys": {
-          "info": "Stimme bei NNYS 2025 ab, um eine exklusive Paint, Abzeichen und Emote Set zu erhalten.",
-          "vote": "Stimme bei NNYS 2025 ab"
-        },
-        "cs2": {
-          "streamers": "35 STREAMER",
-          "tournament": "VON 7TV VERANSTALTETES TURNIER",
-          "event": "3 Tage Event",
-          "header": "Gib deine Tipps ab. Gewinne Preise.",
-          "info": "Von 7TV veranstaltetes CS2-Turnier",
-          "date": "29. Februar – 2. März",
-          "pickems": "Platziere deine pick'ems",
-          "pass": "Hol dir den Pass!",
-          "badges_paints": "Gewinne Abzeichen & Paints.",
-          "description1": "xQc, OhnePixel, JasonTheWeen und 32 weitere Streamer treten gegeneinander an",
-          "description2": "In einem dreitägigen KO-Turnier, das von 7TV veranstaltet wird."
-        }
-      }
-    },
-    "discover": {
-      "title": "Entdecken",
-      "uploads": "Uploads",
-      "followed": "Gefolgte Konten"
-    },
-    "store": {
-      "title": "Store",
-      "redeem": {
-        "title": "Einlösen",
-        "header": "Geschenkcode einlösen",
-        "subtitle": "Löse einen Geschenkcode ein, um exklusive Cosmetics und Vorteile freizuschalten.",
-        "state": {
-          "idle": "Untätigkeit",
-          "loading": "Laden",
-          "success": "Erfolg"
-        },
-        "code": "Code",
-        "shown": "Zeigen",
-        "trial": "Du hast dein Probeabonnement erfolgreich eingelöst"
-      },
-      "purchase": {
-        "success": "Dein Kauf war erfolgreich"
-      },
-      "subscription": {
-        "banner_title_subbed": "Vielen Dank für deine Unterstützung",
-        "banner_title_unsubbed": "Schalte besondere Vorteile frei",
-        "banner_subtitle_subbed": "Viel Spaß mit deinen besonderen Abo-Vorteilen!",
-        "banner_subtitle_unsubbed": "Abonniere, um dein Chat-Erlebnis zu verbessern.",
-        "badge_progress": {
-          "title": "Abzeichen Fortschritt",
-          "left": "{duration} verbleibend"
-        },
-        "benefits": {
-          "title": "Vorteile des Abonnements",
-          "animated_avatar": "Animiertes Profilbild",
-          "personal_emotes": "Persönliche Emotes",
-          "paints": "Nametag Paints",
-          "sub_badge": "Abonnenten Abzeichen",
-          "raffle_tickets": "Los-Tickets"
-        },
-        "raffle": "Globales Emote Raffle",
-        "monthly_paints": "Monatliche Nametag Paints",
-        "your_cosmetics": "Deine Cosmetics",
-        "your_paints": "Deine Paints",
-        "beomce_a_subscriber": "Abonnent werden",
-        "your_badges": "Deine Abzeichen",
-        "top_gifters": "Top Spender",
-        "subscribe": "Abonnieren",
-        "subscribed": "Abonniert",
-        "cancel": "Abonnement kündigen",
-        "reactivate": "Abonnement reaktivieren",
-        "one_monhth": "1 Monat",
-        "one_year": "1 Jahr"
-      },
-      "paint_bundles": {
-        "coming_soon": "Kommt bald",
-        "banner_title": "Bringe dich selbst zum Leuchten",
-        "banner_subtitle": "Nametag Paints verleihen dir in allen Farben Selbstausstrahlung."
-      },
-      "events": {
-        "no_events": "Keine bevorstehenden Events",
-        "xmas": "2024 WEIHNACHTS EVENT: VERSCHENKE 1 SUB, UM EIN SPEZIELLES ABZEICHEN ZU ERHALTEN",
-        "cs2": {
-          "tournament": "Von 7TV veranstaltetes CS2-Turnier",
-          "cosmetics": "Willst du Cosmetics für das Vorhersagen des Ergebnisses erhalten? Klicke unten!",
-          "twitch": "Auf Twitch ansehen",
-          "bundle": "Paket kaufen",
-          "already_subscribed": "Bereits abonniert",
-          "subscribe": "Heute {price}, danach {recurring}",
-          "billing_cycle": "Wird als einmaliger Kauf in Rechnung gestellt",
-          "pickems": {
-            "place": "Platziere Pick'ems",
-            "predict": "Gewinner vorhersagen",
-            "purchase_pass": "Kaufe den Pass"
-          },
-          "pass": {
-            "title": "Pick'ems Pass",
-            "get": "Pass holen",
-            "bundle": "Pass + {variantName(variant)} Abonnement Packet"
-          },
-          "schedule": {
-            "header": "Turnierplan",
-            "stage": "Stufe",
-            "best_of": "Das Beste von",
-            "start_time": "Start Zeit"
-          },
-          "streamers": {
-            "header": "Treffe die Streamer",
-            "info": "Eine prominente Auswahl von Twitch-Streamern stellt aus ihren Communities ein Team zusammen, das in einem Einzelausscheidungsturnier im CS-Stil gegeneinander antritt.",
-            "watch": "Das Hauptevent ansehen auf",
-            "twitch_channel": "7TV Twitch Kanal",
-            "streamer_pov": "oder aus der Sicht deines Lieblings-Streamers."
-          }
-        }
-      }
-    },
-    "admin": {
-      "title": "Admin",
-      "overview": "Übersicht",
-      "welcome": "Willkommen zurück",
-      "enjoy": "Viel Spaß beim moderieren!",
-      "tickets": {
-        "title": "Tickets",
-        "emotes": {
-          "public_listing": "Öffentliche Listung",
-          "personal_use": "Persönliche Nutzung",
-          "resolved": "Erledigt",
-          "not_implemented": "Nicht implementiert"
-        },
-        "emote_table": {
-          "emote_name": "Emote Name",
-          "uploader": "Ersteller",
-          "country": "Land",
-          "tags_flags": "Tags & Flags",
-          "reviewed_by": "Überprüft von"
-        },
-        "reports": "Meldungen",
-        "reports_options": {
-          "all": "Alle",
-          "assigned": "Zugewiesen",
-          "closed": "Geschlossen"
-        },
-        "reports_table": {
-          "reported_by": "Gemeldet von",
-          "target": "Ziel",
-          "description": "Beschreibung",
-          "assigned_to": "Zugewiesen an",
-          "status": "Status",
-          "date": "Datum",
-          "ticket_id": "Meldungs ID",
-          "subject": "Betreff",
-          "details": "Details"
-        },
-        "reports_actions": {
-          "close": "Als geschlossen markieren",
-          "assign_self": "Selbst zuweisen",
-          "add_comment": "Kommentar hinzufügen"
-        }
-      },
-      "codes": {
-        "redeem": "Codes einlösen",
-        "add": "Code(s) hinzufügen",
-        "filters": {
-          "header": "Filter:",
-          "remaining_uses": "Verbleibende Verwendungen"
-        },
-        "search": {
-          "results": "Es wurden {results.totalCount} Ergebnisse gefunden ({results.pageCount} Seiten)"
-        },
-        "attributes": {
-          "name": {
-            "name": "Name",
-            "description": "Beschreibung",
-            "tags": "Tags",
-            "code": "Code",
-            "remaining_uses": "Verbleibende Nutzungen",
-            "active_period": "Aktiver Zeitraum",
-            "effect": "Effekt",
-            "subscription_effect": "Abonnementeffekt",
-            "created_by": "Erstellt von",
-            "created_at": "Erstellt am",
-            "actions": "Aktionen"
-          }
-        },
-        "period": {
-          "unlimited": "Unendlich"
-        },
-        "trial": {
-          "days": "Tages Trial",
-          "no_trial": "Keine Testphase",
-          "none": "Keine"
-        },
-        "system": "System"
-      },
-      "special_events": {
-        "header": "Spezielle Events",
-        "create": "Besonderes Event erstellen",
-        "add": "Besonderes Event hinzufügen",
-        "results": "{results.length} Ergebnisse gefunden",
-        "attributes": {
-          "name": "Name",
-          "description": "Beschreibung",
-          "tags": "Tags",
-          "created_by": "Erstellt von",
-          "created_at": "Erstellt am",
-          "actions": "Aktionen",
-          "create": "Erstellen",
-          "cancel": "Abbrechen"
-        },
-        "system": "System",
-        "no_events": "Keine besonderen Events"
-      },
-      "users": {
-        "id": {
-          "back": "Zurück",
-          "last_updated": "Zuletzt aktualisiert um",
-          "search_last_update": "Suche zuletzt aktualisiert um",
-          "queued": "Für Update eingereiht",
-          "stripe": {
-            "customer": "Stripe Kunde",
-            "view": "Ansicht",
-            "no_customer": "Kein Stripe Kunde zugeordnet",
-            "roles": "Rollen"
-          },
-          "actions": {
-            "header": "Aktionen",
-            "sessions": {
-              "header": "Sitzungen",
-              "create_session": "Erstelle eine neue Sitzung",
-              "delete_all": "Lösche alle Sitzungen",
-              "expiration": "Läuft ab in",
-              "token": "Token",
-              "copy_token": "Kopier Token",
-              "create": "Erstellen",
-              "close": "Schließen"
-            },
-            "connections": {
-              "header": "Verknüpfungen",
-              "kick": "Verknüpfe Kick manuell",
-              "username": "Kick Benutzername"
-            },
-            "entitlements": {
-              "header": "Berechtigungen",
-              "create": "Berechtigungen erstellen",
-              "assign": "Berechtigungen manuell zuweisen",
-              "assign_to": "Berechtigungen zuweisen an",
-              "remove_all": "Alle Berechtigungen entfernen",
-              "view": "Berechtigungen anschauen",
-              "showing": "Anzeigen der zugewiesenen Berechtigungen für\n"
-            }
-          },
-          "subscription": {
-            "header": "Abonnement",
-            "period": {
-              "header": "Abonnementlaufzeiten",
-              "key": "Schlüssel",
-              "value": "Wert",
-              "id": "ID"
-            },
-            "copy": {
-              "ulid": "Kopiere ULID",
-              "uuid": "Kopiere UUID"
-            },
-            "provider": {
-              "id": "Anbieter ID",
-              "view": "Ansicht"
-            },
-            "product": {
-              "id": "Produkt ID",
-              "view": "Ansicht",
-              "start": "Start",
-              "end": "Ende",
-              "is_trial": "Ist Testphase?",
-              "auto_renew": "Automatische Erneuerung?",
-              "gifted": {
-                "header": "Geschenkt?",
-                "yes": "Ja, von",
-                "no": "Nein"
-              },
-              "created_by": "Erstellt von",
-              "redeem": "Code einlösen",
-              "invoice": "Rechnung",
-              "system": "System",
-              "variant": "Produkt Variante"
-            }
-          },
-          "not_found": "Benutzer nicht gefunden"
-        },
-        "layout": {
-          "users": "Benutzer"
-        },
-        "page": {
-          "manage": {
-            "header": "Verwalten",
-            "single_user": "Verwalte einen Nutzer"
-          },
-          "actions": {
-            "header": "Aktionen",
-            "sub_benefits_job": {
-              "header": "Vorteile des Abonnements",
-              "manually": "Führe den Abonnementvorgang manuell aus, um die Berechtigungen und Vorteile für alle Benutzer neu zu berechnen.",
-              "rerun": "Wiederholen"
-            }
-          }
-        }
-      }
-    },
-    "emote": {
-      "use_emote": "Emote nutzen",
-      "add_to": "Hinzufügen zu...",
-      "transfer": "Übertragen",
-      "merge": "Zusammenfügen",
-      "size": "Größe",
-      "copy_link": "Link kopieren"
-    },
-    "user": {
-      "about": "Über",
-      "active_emotes": "Aktive Emotes",
-      "uploaded": "Hochgeladen",
-      "uploaded_emotes": "Hochgeladene Emotes"
-    },
-    "settings": {
-      "account": {
-        "title": "Konto",
-        "profile": {
-          "details": "Passe deine Präferenzen an und stelle Details entsprechend deiner individuellen Ansprüche ein",
-          "display_name": "Anzeigename",
-          "display_name_description": "Wähle eine Hauptverbindung, die für deinen Anzeigenamen und dein statisches Profilbild verwendet wird",
-          "profile_picture_description": "Wähle ein Profilbild aus, das auf allen Plattformen angezeigt wird",
-          "update_profile_picture": "Profilbild aktualisieren"
-        },
-        "connections": {
-          "details": "Verknüpfe und verwalte externe Konten, um den Zugriff zu optimieren und die Kompatibilität innerhalb der Plattform zu verbessern"
-        },
-        "security": {
-          "title": "Sicherheit",
-          "details": "Verwalte deine Konto-Sicherheit",
-          "2fa": "Zwei-Faktor-Authentifizierung",
-          "2fa_details": "Erhöhe die Sicherheit deines Kontos mit der Zwei-Faktor-Authentifizierung (2FA)",
-          "email_details": "Erhalte einen Bestätigungscode per E-Mail",
-          "authenticator_app": "Authentifizierungs App",
-          "authenticator_app_details": "Installiere eine App, um deinen Bestätigungscode zu generieren",
-          "sign_out_everywhere": "Überall abmelden",
-          "sign_out_everywhere_details": "Sorge für Sicherheit, indem du dich mit einem einzigen Klick von allen Geräten abmeldest",
-          "delete_account_details": "Entferne dauerhaft alle persönlichen Informationen und zugehörigen Daten von der Plattform und lösche dein Konto"
-        }
-      },
-      "appearance": {
-        "title": "Erscheinungsbild",
-        "details": "Verändere dein Erscheinungsbild",
-        "theme": {
-          "header": "Design",
-          "options": {
-            "system": "System",
-            "dark": "Dunkel",
-            "light": "Hell"
-          }
-        },
-        "motion": {
-          "header": "Reduzierte Bewegung",
-          "options": {
-            "system": "System",
-            "enabled": "Aktiviert",
-            "disbaled": "Deaktiviert"
-          }
-        },
-        "right-to-left-layout": {
-          "header": "Richtung des Website Layouts",
-          "options": {
-            "ltr": "Links nach rechts",
-            "rtl": "Rechts nach links"
-          }
-        }
-      },
-      "editors": {
-        "details": "Verwalte und passe deine Editoren oder Kanäle an, die du selbst bearbeitest",
-        "editing_for": "Editor für",
-        "add_editor": "Editor hinzufügen",
-        "not_allowed": "Es ist dir nicht erlaubt Editoren für diesen Benutzer zu verwalten"
-      },
-      "notifications": {
-        "details": "Echtzeit-Updates und Warnungen, die Benutzer über wichtige Ereignisse, Nachrichten und Aktivitäten auf der Website oder Anwendung informiert halten"
-      },
-      "blocked": {
-        "title": "Blockiert",
-        "details": "Verwalte deine eingeschränkten oder verbotenen Inhalte, Benutzer oder Aktivitäten",
-        "add_user": "Blockierten Nutzer hinzufügen"
-      },
-      "billing": {
-        "title": "Rechnungsbeleg",
-        "subscription": {
-          "details": "Lorem ipsum dolor sit, amet consectetur adipisicing elit. Magni incidunt numquam itaque, amet ad, pariatur possimus illo atque sunt asperiores molestias autem ex nobis consequuntur culpa. Corporis possimus aspernatur soluta.",
-          "use_credits": "Abo-Credits verwenden",
-          "use_credits_details": "Deine Abo-Credits werden für die nächste Abrechnung bevorzugt verwendet",
-          "cancelled": "Abonnement gekündigt",
-          "cancelled_details": "Dein Abonnement wurde gekündigt und deine Vorteile verfallen am {date}"
-        },
-        "history": {
-          "title": "Rechnungsverlauf",
-          "details": "Alle mit deinem Konto verbundenen Zahlungsaktivitäten einsehen, z. B. frühere Abrechnungen und Transaktionen"
-        },
-        "payment_methods": {
-          "details": "Prüfe und aktualisiere deine bevorzugten Zahlungsmethoden",
-          "add_new": "Neue hinzufügen",
-          "card": {
-            "title": "Kreditkarteninformationen",
-            "ends_in": "Endet mit {digits}",
-            "expires": "Läuft ab am {month}/{year}",
-            "address": "Adresse",
-            "name": "Name"
-          }
-        },
-        "table": {
-          "status": "Status",
-          "amount": "Menge",
-          "invoice": "Rechnung"
-        }
-      },
-      "user_table": {
-        "name": "Name",
-        "last_modified": "Zuletzt geändert",
-        "permissions": "Berechtigungen"
-      }
-    },
-    "link": {
-      "linking": "Konto wird verknüpft...",
-      "linking_successful": "Konto erfolgreich verknüpft",
-      "linking_failed": "Verknüpfung fehlgeschlagen"
-    },
-    "extension": {
-      "login": "Anmeldung läuft...",
-      "login_successful": "Angemeldet",
-      "login_failed": "Fehler beim Anmelden",
-      "window": "Stelle sicher, dass du dieses Fenster über die Erweiterung öffnest"
-    }
-  }
+	"page_titles": {
+		"suffix": "7TV",
+		"admin_suffix": "7TV Admin",
+		"trending_emotes": "Angesagte Emotes",
+		"top_emotes": "Top Emotes",
+		"global_emotes": "Globale Emotes",
+		"new_emotes": "Neue Emotes",
+		"bookmarked_emotes": "Gespeicherte Emotes",
+		"bookmarked_emote_sets": "Gespeicherte Emote Sets",
+		"bookmarked_users": "Gespeicherte Benutzer",
+		"account_settings": "Kontoeinstellungen",
+		"editor_settings": "Editor Einstellungen",
+		"notification_settings": "Benachrichtigungseinstellungen",
+		"blocked_settings": "Blockierte Einstellungen",
+		"billing_settings": "Abrechnungseinstellungen",
+		"admin_emote_public_listing": "Emote-Anfragen zur öffentlichen Nutzung",
+		"admin_emote_personal_use": "Emote-Anfragen zur persönlichen Nutzung",
+		"admin_emote_resolved": "Erledigte Emote Tickets"
+	},
+	"page_errors": {
+		"not_found": "Die Seite, nach der du suchst, konnte nicht gefunden werden.",
+		"forbidden": "Du hast nicht die Berechtigung, diese Seite zu sehen.",
+		"unauthorized": "Du bist nicht autorisiert, diese Seite zu sehen.",
+		"unexpected": "Du kannst probieren, die Seite neu zu laden. Wenn das Problem besteht, kontaktiere uns bitte.",
+		"generic": "Ein Fehler ist aufgetreten.",
+		"emote_set_load": "Ein Fehler ist beim Laden des Emote Set aufgetreten",
+		"emote_set_not_found": "Emote Set nicht gefunden",
+		"user": "Nutzer konnte nicht geladen werden"
+	},
+	"words": {
+		"from": "von",
+		"to": "zu",
+		"with": "mit",
+		"by": "von"
+	},
+	"common": {
+		"sign_in": "Anmelden",
+		"sign_out": "Abmelden",
+		"go_back": "Zurück",
+		"super_admin": "Super Admin",
+		"skip_to_content": "Zum Inhalt springen",
+		"emotes": "{count, plural, one {Emote} other {Emotes}}",
+		"emote_sets": "{count, plural, one {Emote Set} other {Emote Sets}}",
+		"users": "{count, plural, one {Nutzer} other {Nutzer}}",
+		"channels": "{count, plural, one {Kanal} other {Kanäle}}",
+		"followers": "{count, plural, one {Follower} other {Follower}}",
+		"items": "{count, plural, one {Gegenstand} other {Gegenstände}}",
+		"subscriptions": "{count, plural, one {Abonnement} other {Abonnements}}",
+		"payment_methods": "{count, plural, one {Zahlungsmethode} other {Zahlungsmethoden}}",
+		"date": "Datum",
+		"help": "Hilfe",
+		"for": "für",
+		"error": "Fehler",
+		"loading": "Lädt...",
+		"paint_bundles": "Paint Bundles",
+		"notifications": "Benachrichtigungen",
+		"connections": "Verknüpfungen",
+		"direct_messages": "Direktnachrichten",
+		"mod_comments": "Mod Kommentare",
+		"profile_picture": "Profilbild",
+		"suggested_emotes": "Vorgeschlagene Emotes",
+		"personal_emotes": "Persönliche Emotes",
+		"no_more_emotes": "Keine Emotes mehr",
+		"no_emotes": "Keine Emotes",
+		"your_subscription": "Dein Abonnement",
+		"theme": "Design",
+		"language": "Sprache",
+		"developer_portal": "Entwicklerportal",
+		"faq": "Häufig gestellte Fragen",
+		"faq_short": "FAQ",
+		"privacy": "Datenschutzrichtlinien",
+		"tos": "Nutzungsbedingungen",
+		"trending": "Im Trend",
+		"top": "Top",
+		"global": "Global",
+		"new": "Neu",
+		"Weekly": "Wöchentlich",
+		"Monthly": "Monatlich",
+		"Today": "Heute",
+		"news": "Neuigkeiten",
+		"Default_set": "Standard Set",
+		"following": "Folgt",
+		"activity": "Aktivität",
+		"info": "Info",
+		"analytics": "Analysen",
+		"statistics": "Statistiken",
+		"contact": "Kontakt",
+		"cosmetics": "Cosmetics",
+		"editors": "Editoren",
+		"active": "Aktiv",
+		"profile": "Profil",
+		"pinned": "Angeheftet",
+		"settings": "Einstellungen",
+		"delete_account": "Konto löschen"
+	},
+	"labels": {
+		"enter_text": "Text eingeben",
+		"redeem": "Code eingeben",
+		"search": "Suche",
+		"refetch": "Erneut abrufen",
+		"manage_connections": "Verknüpfungen verwalten",
+		"manage_editors": "Editoren verwalten",
+		"none": "Keine",
+		"search_user": "Benutzer suchen",
+		"search_country": "Land suchen",
+		"search_emote_set": "Emote Set suchen",
+		"search_users": "{count, plural, one {Benutzer suchen} other {Benutzer suchen}}",
+		"tags": "Tags",
+		"close": "Schließen",
+		"contribute": "Beitragen",
+		"enter_tags": "Tags eingeben",
+		"tag_limit_reached": "Tag Limit von {limit} erreicht",
+		"filters": "Filter",
+		"no_filters": "Keine Filter",
+		"emote_name": "Emote Name",
+		"copy_link": "Link kopieren",
+		"create_emote_set": "Erstelle ein neues Set",
+		"emote_set_name": "Emote Set Name",
+		"emote_attribution": "Emote Zuweisung",
+		"select": "Auswählen",
+		"selection_mode": "Auswahlmodus",
+		"edit": "Bearbeiten",
+		"capacity": "Kapazität",
+		"enable": "Aktivieren",
+		"disable": "Deaktivieren",
+		"disabled": "Deaktiviert",
+		"more": "Mehr",
+		"actions": "Aktionen",
+		"download": "Herunterladen",
+		"report": "Melden",
+		"delete": "Löschen",
+		"time_select": {
+			"week": "Diese Woche",
+			"month": "Diesen Monat",
+			"year": "Dieses Jahr"
+		},
+		"gift": "Verschenken",
+		"follow": "Folgen",
+		"connect": "Verbinden",
+		"disconnect": "Trennen",
+		"email": "E-Mail",
+		"password": "Passwort",
+		"all": "Alles",
+		"other": "Anderes",
+		"cancel": "Abbrechen",
+		"confirm": "Bestätigen",
+		"proceed": "Fortfahren",
+		"save": "Speichern",
+		"remove": "Entfernen",
+		"accept": "Akzeptieren",
+		"deny": "Ablehnen",
+		"enter": "Bestätigen"
+	},
+	"themes": {
+		"system": "System",
+		"dark": "Dunkel",
+		"light": "Hell"
+	},
+	"flags": {
+		"global": "Global",
+		"trending": "Im Trend",
+		"overlaying": "Überlagernd",
+		"default": "Standard",
+		"personal": "Persönlich",
+		"listed": "Gelistet",
+		"unlisted": "Ungelistet",
+		"personal_use": "Persönliche Nutzung",
+		"deleted": "Gelöscht",
+		"private": "Privat",
+		"personal_use_approved": "Persönliche Nutzung freigegeben",
+		"personal_use_denied": "Persönliche Nutzung abgelehnt",
+		"personal_use_pending": "Überprüfung zur persönlichen Nutzung ausstehend",
+		"renamed": "Umbenannt",
+		"nsfw": "NSFW",
+		"editor_flags": {
+			"pending": "Ausstehend",
+			"accepted": "Akzeptiert",
+			"rejected": "Abgelehnt",
+			"you_accepted": "Von dir akzeptiert",
+			"you_rejected": "Von dir abgelehnt"
+		}
+	},
+	"notifications": {
+		"system": "System",
+		"approved_for_public": "Dein Emote {emote} wurde zur öffentlichen Listung freigegeben."
+	},
+	"sub_info": {
+		"plan": "Abonnement",
+		"free": "Kostenlos",
+		"gifted_by": "Geschenkt von",
+		"ends": "Abo endet",
+		"total": "Gesamt",
+		"credits": "Abo-Credits"
+	},
+	"file_limits": {
+		"max_size": "{size} maximale Dateigröße",
+		"max_resolution": "{width}x{height} maximale Auflösung",
+		"max_frames": "{count} maximale Frames",
+		"resolution_error": "Die Auflösung darf {width}x{height} nicht überschreiten",
+		"duration_error": "Die Dauer muss {duration} Sekunden oder weniger betragen"
+	},
+	"dialogs": {
+		"sign_in": {
+			"title": "Bei 7TV anmelden",
+			"subtitle": "Melde dich an oder erstelle ein Konto, um fortzufahren",
+			"continue_with": "Fortfahren mit {platform}",
+			"trouble": "Schwierigkeiten bei der Anmeldung?",
+			"legal_yapping": "Durch das Anmelden stimmst du unseren",
+			"and": "und",
+			"linking_new": "Du hast bereits ein 7TV-Konto und möchtest eine neue Verbindung hinzufügen? Meld dich mit deiner bestehenden Verbindung an und verknüpfe die neue in den",
+			"settings": "Einstellungen"
+		},
+		"search": {
+			"emotes": "Emotes",
+			"users": "Benutzer"
+		},
+		"upload": {
+			"title": "Emote hochladen",
+			"untitled": "Unbetitelt",
+			"chat": "Sende eine Nachricht",
+			"drag_drop": "Drag & Drop um hochzuladen, oder",
+			"browse_files": "Dateien durchsuchen",
+			"accept_rules": "Ich akzeptiere die Regeln und Richtlinien",
+			"discard": "Verwerfen",
+			"upload_guidelines": "Emote Upload Richtlinien",
+			"upload": "Hochladen"
+		},
+		"emote_set": {
+			"title": "Aktives Emote Set",
+			"create": "Erstelle ein Emote Set",
+			"name": "Emote Set Name",
+			"label": "Name",
+			"confirm": "Erstellen",
+			"copy_set": "Set kopieren",
+			"special": "Spezial",
+			"favourite_sets": {
+				"title": "Favorisierte Emote Sets",
+				"add": "Hinzufügen und umbenennen für alle",
+				"remove": "Aus allen entfernen"
+			},
+			"mass_select_feature": {
+				"add": "Zu Emote Set hinzufügen",
+				"remove": "Aus Emote Set entfernen",
+				"amount_selected_label": "/20 Ausgewählt"
+			},
+			"default_emote_set": {
+				"remove": "Emote aus {set} entfernen",
+				"add": "Emote zu {set} hinzufügen",
+				"conflicting_name": "Namenskonflikt"
+			}
+		},
+		"manage_aliases": {
+			"title": "Emote Aliase verwalten",
+			"add_placeholder": "Neuen Alias hinzufügen.."
+		},
+		"rename_emote": {
+			"title": "Emote in {set} umbenennen",
+			"input_placeholder": "Neuer Emote Name",
+			"confirmation_message": "Möchtest du dieses Emote in {set} wirklich umbenennen?",
+			"confirm": "Umbenennen"
+		},
+		"remove_emote_from_set": {
+			"title": "Emote aus {set} entfernen",
+			"warning_message": "Möchtest du {emote} wirklich aus {set} entfernen?",
+			"confirm": "Entfernen"
+		},
+		"add_emote": {
+			"title": "Füge {emote} hinzu zu",
+			"change_name": "Emote Namen ändern",
+			"confirm": "Bestätigen",
+			"confirm_changes": "{count, plural, one {1 Änderung bestätigen} other {{count} Änderungen bestätigen}}"
+		},
+		"emote_ticket": {
+			"emote_queue": "Emote Warteschlange",
+			"activity": "Aktivität",
+			"comments": "Kommentare"
+		},
+		"emote_context_menu": {
+			"add_remove_emote": "Emote hinzufügen/entfernen",
+			"edit_emote_alias": "Emote Alias bearbeiten",
+			"remove_emote": "Emote aus Set entfernen",
+			"open_in_new_tab": "In neuem Tab öffnen",
+			"copy_emote_link": "Emote Link kopieren"
+		},
+		"cart": {
+			"title": "Dein Warenkorb",
+			"duration": "Dauer",
+			"price": "Preis",
+			"preview": "Vorschau",
+			"purchase_as_gift": "Als Geschenk kaufen",
+			"total": "Gesamt"
+		},
+		"editor": {
+			"permissions": "Editor Berechtigungen festlegen",
+			"super_admin": "Super Admin",
+			"emote_sets": "Emote Sets",
+			"admin": "Admin",
+			"emotes": "Emotes",
+			"user": "Benutzer",
+			"manage_personal_emotes": "Persönliche Emote Sets verwalten",
+			"confirm": "Bestätigen",
+			"no_editors": "Keine Editoren zum Anzeigen",
+			"permissions_details": {
+				"manage": "Verwalten",
+				"create": "Erstellen",
+				"transfer": "Übertragen",
+				"manage_profile": "Profil verwalten",
+				"manage_emotes": "Emotes verwalten",
+				"manage_billing": "Zahlungen verwalten",
+				"manage_editors": "Editoren verwalten",
+				"view_billing": "Zahlungsinformationen ansehen"
+			}
+		},
+		"emote_info": {
+			"processing": "Dieses Emote wird noch verarbeitet",
+			"refresh": "Aktualisieren",
+			"download": "Herunterladen"
+		},
+		"copy_emotes": {
+			"title": "Kopiere ausgewählte Emotes nach"
+		},
+		"default_set": {
+			"title": "Standard Emote Set"
+		},
+		"delete_account": {
+			"warning": "Warnung",
+			"warning_message": "Durch diese Aktion wird dein Konto endgültig gelöscht. Du kannst diese Aktion nicht rückgängig machen.",
+			"choose_reasons": "Wähle die Gründe für die Löschung des Kontos",
+			"reasons": {
+				"no_longer_use": "Ich benutze 7TV nicht mehr",
+				"privacy_concerns": "Bedenken hinsichtlich des Datenschutzes",
+				"not_useful": "Nicht hilfreich",
+				"other": "Andere"
+			},
+			"confirm_username": "Gib deinen Nutzernamen zur Bestätigung ein"
+		},
+		"delete_emote_or_set": {
+			"title": "Lösche {name}",
+			"warning_message_emote": "Durch diese Aktion wird dein Emote endgültig gelöscht. Du kannst diese Aktion nicht rückgängig machen.",
+			"warning_message_set": "Durch diese Aktion wird dein Emote Set endgültig gelöscht. Du kannst diese Aktion nicht rückgängig machen.",
+			"reason": "Grund",
+			"reason_for_deletion": "Grund des Löschens"
+		},
+		"edit_emote": {
+			"title": "Bearbeite {emote}"
+		},
+		"edit_emote_set": {
+			"title": "Emote Set bearbeiten",
+			"show_on_profile": "Im Profil anzeigen",
+			"publicly_listed": "Öffentlich gelistet"
+		},
+		"remove_emote": {
+			"title": "Ausgewählte Emotes aus {set} entfernen"
+		},
+		"report_emote": {
+			"title": "Emote melden",
+			"choose_reasons": "Wähle den Grund",
+			"reasons": {
+				"my_work": "Ich habe dieses Emote erstellt, aber es wurde von jemand anderem hochgeladen",
+				"duplicate": "Dieses Emote ist ein Duplikat",
+				"sexual": "Dieses Emote enthält pornografische oder übermäßig sexualisierte Darstellungen",
+				"violance": "Dieses Emote zeigt extreme Gewalt oder Blut",
+				"its_me": "Dieses Emote stellt mich dar, und ich möchte das nicht",
+				"offensive": "Ich finde dieses Emote anstößig",
+				"other": "Anderes"
+			},
+			"additional_info": "Zusätzliche Informationen",
+			"disclaimer": "Ein Missbrauch der Meldefunktion kann einen Entzug deines Zugangs zur Folge haben."
+		},
+		"transfer_emote": {
+			"title": "Übertrage {emote}",
+			"details": "Dadurch wird {emote} übertragen.",
+			"receipient": "Emote Empfänger",
+			"transfer": "Übertragen"
+		},
+		"badge": {
+			"title": "Abzeichen"
+		},
+		"subscription": {
+			"gifted_by": "Dein Abonnement wurde dir geschenkt von",
+			"cancel_notice": "Wenn du dein Abonnement jetzt kündigst, verlierst du sofort den Zugang zu deinen Abonnementvorteilen. Möchtest du dein Abonnement wirklich kündigen?",
+			"cancel_confirmation": "Möchtest du dein Abonnement wirklich kündigen? Am Ende deines aktuellen Abrechnungszeitraums verlierst du den Zugang zu deinen Abonnementvorteilen.",
+			"confirm": "Bestätigen"
+		},
+		"error": {
+			"title": "Error"
+		},
+		"pickems": {
+			"gift": {
+				"title": "Verschenke den Pick'ems Pass",
+				"gift_to": "Verschenke einen Pick-Ems-Pass an",
+				"recipient": "Empfänger auswählen",
+				"back": "Zurück",
+				"continue": "Fortfahren"
+			}
+		},
+		"gift": {
+			"title": "Verschenke 1",
+			"gift_to": "Verschenke 1 {variant} an",
+			"recipient": "Wähle einen Empfänger aus"
+		},
+		"paint": {
+			"title": "Paint"
+		},
+		"buttons": {
+			"back": "Zurück",
+			"continue": "Weiter"
+		},
+		"emote-events": {
+			"upload": {
+				"action": "Hochgeladen"
+			},
+			"process": {
+				"start": "Neue Verarbeitung gestartet",
+				"success": "Verarbeitung erfolgreich abgeschlossen",
+				"fail": "Verarbeitung fehlgeschlagen",
+				"cancel": "Verarbeitung abgebrochen"
+			},
+			"change_name": {
+				"action": "Umbenannt"
+			},
+			"merge": {
+				"action": "Zusammengefügt"
+			},
+			"change_owner": {
+				"action": "Eigentumsrechte wurden übertragen"
+			},
+			"change_tags": {
+				"action": "Tags gesetzt auf"
+			},
+			"change_flags": {
+				"approved_public": {
+					"action": "Für die öffentliche Listung freigegeben"
+				},
+				"removed_public": {
+					"action": "Aus der öffentlichen Listung entfernt"
+				},
+				"approved_personal": {
+					"action": "Persönliche Nutzung freigegeben"
+				},
+				"rejected_personal": {
+					"action": "Für persönliche Nutzung abgelehnt"
+				},
+				"added_overlaying": {
+					"action": "Die Überlagerungsmarkierung wurde hinzugefügt"
+				},
+				"removed_overlaying": {
+					"action": "Die Überlagerungsmarkierung wurde entfernt"
+				},
+				"added_private": {
+					"action": "Private Markierung hinzugefügt"
+				},
+				"removed_private": {
+					"action": "Private Markierung entfernt"
+				}
+			},
+			"delete": {
+				"action": "Gelöscht"
+			}
+		}
+	},
+	"pages": {
+		"activity": {
+			"title": "Aktivität",
+			"emote": {
+				"deleted_emote": "Gelöschtes Emote",
+				"deleted_set": "Gelöschtes Set",
+				"by": "von",
+				"created": "Erstellt",
+				"changed_tags": "Tags geändert für",
+				"changed_capacity": "Kapazität geändert für",
+				"added": "Hinzugefügt",
+				"removed": "Emote entfernt",
+				"renamed": "Umbenanntes Emote",
+				"in": "in",
+				"from": "von",
+				"to": "zu",
+				"deleted": "Gelöscht"
+			},
+			"user": {
+				"changed_paint": "Aktive Paint geändert von",
+				"changed_badge": "Aktives Abzeichen geändert von",
+				"removed": "Entfernt",
+				"connection": "Verknüpfungen",
+				"changed_set": "Aktives Emote Set geändert von",
+				"added": "Hinzugefügt",
+				"no_badge": "Kein Abzeichen",
+				"no_paint": "Keine Paint",
+				"deleted": "Gelöscht"
+			}
+		},
+		"auth": {
+			"title": {
+				"logging": "Anmeldung läuft...",
+				"logged": "Angemeldet",
+				"failed": "Fehler beim Anmelden"
+			},
+			"state": {
+				"logging": "Anmeldung läuft...",
+				"logged": "Angemeldet",
+				"failed": {
+					"title": "Anmeldung fehlgeschlagen",
+					"message": "Stelle sicher, dass du dieses Fenster über die Erweiterung öffnest"
+				}
+			}
+		},
+		"home": {
+			"title": "Start",
+			"features": {
+				"emote_slots": "1000 Emote Slots",
+				"emote_slots_info": "Jeder erhält 1000 personalisierbare Emote Slots pro Kanal, und das kostenlos. Bringe all deine Emotes an einem Ort unter.",
+				"emote_slots_button": "Emotes durchsuchen",
+				"emote_sets": "Emote Sets",
+				"emote_sets_info": "Gruppiere Emotes in anpassbare Sets, die mit anderen Nutzern geteilt oder schnell auf deinem Kanal ausgetauscht werden können.",
+				"emote_sets_button": "Erstelle ein Emote Set",
+				"custom_emotes": "Benutzerdefinierte Emote Namen",
+				"custom_emotes_info": "Magst Du den Namen eines Emotes nicht, den der Autor vergeben hat? Kein Problem, Du kannst den Namen für Deinen eigenen Kanal anpassen.",
+				"custom_emotes_button": "Emotes durchsuchen",
+				"real-time": "Echtzeit Aktualisierungen",
+				"real-time_info": "Das Ändern von Emotes in deinem Kanal erfolgt sofort für alle Zuschauer. Kein F5 mehr nötig, kein Warten mehr.",
+				"real-time_button": "Lade die Erweiterung herunter",
+				"large_community": "Große Community",
+				"large_community_info": "7TV bietet mehr als 2.000.000 tägliche Nutzer und verfügt über eine Bibliothek mit über 1.000.000 öffentlichen Emotes.",
+				"large_community_button": "Tritt unserem Discord bei",
+				"next_gen": "Next-gen Formate",
+				"next_gen_info": "Wir verwenden neuere, stärker optimierte Bildformate wie WebP und AVIF, um die Bandbreitennutzung zu reduzieren.",
+				"next_gen_button": "Lade die Erweiterung herunter"
+			}
+		},
+		"help": {
+			"title": "Hilfe"
+		},
+		"directory": {
+			"title": "Verzeichnis",
+			"bookmarked": "Mit Lesezeichen versehen",
+			"sorting": {
+				"title": "Sortierung",
+				"alphabetical": "Alphabetisch",
+				"upload_date": "Upload-Datum"
+			},
+			"filters": {
+				"animated": "Animiert",
+				"static": "Statisch",
+				"overlaying": "Überlagernd",
+				"personal_use": "Persönliche Nutzung",
+				"exact_match": "Genaue Übereinstimmung"
+			},
+			"size": {
+				"title": "Größe",
+				"any": "Jede Größe"
+			}
+		},
+		"landing": {
+			"start": "Beginne deine Reise mit Hunderten von Emotes und Funktionen, die dein Chat-Erlebnis verbessern. Lade die offizielle 7TV-Erweiterung oder andere Tools von Drittanbietern herunter.",
+			"developers": {
+				"header": "Quellcode verfügbar",
+				"info": "Unsere gesamte Codebasis ist auf GitHub unter einer Quelloffenen Lizenz verfügbar. Jeder kann diese einsehen und zu ihr beitragen."
+			},
+			"download": {
+				"start": "Beginne deine Reise mit Hunderten von Emotes und Funktionen, die dein Chat-Erlebnis verbessern. Lade die offizielle 7TV-Erweiterung oder andere Tools von Drittanbietern herunter.",
+				"extension": "Browser Erweiterung",
+				"stable": "Stabile Version",
+				"nightly": "Nightly Version",
+				"chatterino": "Chatterino",
+				"mobile": {
+					"apps": "Mobile Apps"
+				},
+				"bots": {
+					"header": "Chat Bots"
+				}
+			},
+			"features": {
+				"header": "Warum 7TV?",
+				"info": "Unsere Plattform bietet eine Vielzahl nützlicher Funktionen, die dein Chat-Erlebnis verbessern werden."
+			},
+			"footer": {
+				"affiliated": "7TV gehört nicht zu Twitch, Kick, YouTube oder Discord",
+				"privacy_policy": "Datenschutzerklärung",
+				"tos": "Nutzungsbedingungen"
+			},
+			"hero": {
+				"platform": "Die Emote Plattform",
+				"all": "für alle",
+				"download": "Herunterladen",
+				"manage": "Verwalte hunderte von Emotes für deinen Twitch-, Kick- oder YouTube-Kanal. Verbessere dein Chat-Erlebnis.",
+				"more": "Mehr erfahren",
+				"xmas": {
+					"header": "Weihnachts-Abo-Aktion",
+					"info": "Verschenke dieses Weihnachten 1 Abo an jemanden und erhalte ein besonderes Abzeichen!",
+					"gift": "Abo verschenken"
+				},
+				"nnys": {
+					"info": "Stimme bei NNYS 2025 ab, um eine exklusive Paint, Abzeichen und Emote Set zu erhalten.",
+					"vote": "Stimme bei NNYS 2025 ab"
+				},
+				"cs2": {
+					"streamers": "35 STREAMER",
+					"tournament": "VON 7TV VERANSTALTETES TURNIER",
+					"event": "3 Tage Event",
+					"header": "Gib deine Tipps ab. Gewinne Preise.",
+					"info": "Von 7TV veranstaltetes CS2-Turnier",
+					"date": "29. Februar – 2. März",
+					"pickems": "Platziere deine pick'ems",
+					"pass": "Hol dir den Pass!",
+					"badges_paints": "Gewinne Abzeichen & Paints.",
+					"description1": "xQc, OhnePixel, JasonTheWeen und 32 weitere Streamer treten gegeneinander an",
+					"description2": "In einem dreitägigen KO-Turnier, das von 7TV veranstaltet wird."
+				}
+			}
+		},
+		"discover": {
+			"title": "Entdecken",
+			"uploads": "Uploads",
+			"followed": "Gefolgte Konten"
+		},
+		"store": {
+			"title": "Store",
+			"redeem": {
+				"title": "Einlösen",
+				"header": "Geschenkcode einlösen",
+				"subtitle": "Löse einen Geschenkcode ein, um exklusive Cosmetics und Vorteile freizuschalten.",
+				"state": {
+					"idle": "Untätigkeit",
+					"loading": "Laden",
+					"success": "Erfolg"
+				},
+				"code": "Code",
+				"shown": "Zeigen",
+				"trial": "Du hast dein Probeabonnement erfolgreich eingelöst"
+			},
+			"purchase": {
+				"success": "Dein Kauf war erfolgreich"
+			},
+			"subscription": {
+				"banner_title_subbed": "Vielen Dank für deine Unterstützung",
+				"banner_title_unsubbed": "Schalte besondere Vorteile frei",
+				"banner_subtitle_subbed": "Viel Spaß mit deinen besonderen Abo-Vorteilen!",
+				"banner_subtitle_unsubbed": "Abonniere, um dein Chat-Erlebnis zu verbessern.",
+				"badge_progress": {
+					"title": "Abzeichen Fortschritt",
+					"left": "{duration} verbleibend"
+				},
+				"benefits": {
+					"title": "Vorteile des Abonnements",
+					"animated_avatar": "Animiertes Profilbild",
+					"personal_emotes": "Persönliche Emotes",
+					"paints": "Nametag Paints",
+					"sub_badge": "Abonnenten Abzeichen",
+					"raffle_tickets": "Los-Tickets"
+				},
+				"raffle": "Globales Emote Raffle",
+				"monthly_paints": "Monatliche Nametag Paints",
+				"your_cosmetics": "Deine Cosmetics",
+				"your_paints": "Deine Paints",
+				"beomce_a_subscriber": "Abonnent werden",
+				"your_badges": "Deine Abzeichen",
+				"top_gifters": "Top Spender",
+				"subscribe": "Abonnieren",
+				"subscribed": "Abonniert",
+				"cancel": "Abonnement kündigen",
+				"reactivate": "Abonnement reaktivieren",
+				"one_monhth": "1 Monat",
+				"one_year": "1 Jahr"
+			},
+			"paint_bundles": {
+				"coming_soon": "Kommt bald",
+				"banner_title": "Bringe dich selbst zum Leuchten",
+				"banner_subtitle": "Nametag Paints verleihen dir in allen Farben Selbstausstrahlung."
+			},
+			"events": {
+				"no_events": "Keine bevorstehenden Events",
+				"xmas": "2024 WEIHNACHTS EVENT: VERSCHENKE 1 SUB, UM EIN SPEZIELLES ABZEICHEN ZU ERHALTEN",
+				"cs2": {
+					"tournament": "Von 7TV veranstaltetes CS2-Turnier",
+					"cosmetics": "Willst du Cosmetics für das Vorhersagen des Ergebnisses erhalten? Klicke unten!",
+					"twitch": "Auf Twitch ansehen",
+					"bundle": "Paket kaufen",
+					"already_subscribed": "Bereits abonniert",
+					"subscribe": "Heute {price}, danach {recurring}",
+					"billing_cycle": "Wird als einmaliger Kauf in Rechnung gestellt",
+					"pickems": {
+						"place": "Platziere Pick'ems",
+						"predict": "Gewinner vorhersagen",
+						"purchase_pass": "Kaufe den Pass"
+					},
+					"pass": {
+						"title": "Pick'ems Pass",
+						"get": "Pass holen",
+						"bundle": "Pass + {variantName(variant)} Abonnement Packet"
+					},
+					"schedule": {
+						"header": "Turnierplan",
+						"stage": "Stufe",
+						"best_of": "Das Beste von",
+						"start_time": "Start Zeit"
+					},
+					"streamers": {
+						"header": "Treffe die Streamer",
+						"info": "Eine prominente Auswahl von Twitch-Streamern stellt aus ihren Communities ein Team zusammen, das in einem Einzelausscheidungsturnier im CS-Stil gegeneinander antritt.",
+						"watch": "Das Hauptevent ansehen auf",
+						"twitch_channel": "7TV Twitch Kanal",
+						"streamer_pov": "oder aus der Sicht deines Lieblings-Streamers."
+					}
+				}
+			}
+		},
+		"admin": {
+			"title": "Admin",
+			"overview": "Übersicht",
+			"welcome": "Willkommen zurück",
+			"enjoy": "Viel Spaß beim moderieren!",
+			"tickets": {
+				"title": "Tickets",
+				"emotes": {
+					"public_listing": "Öffentliche Listung",
+					"personal_use": "Persönliche Nutzung",
+					"resolved": "Erledigt",
+					"not_implemented": "Nicht implementiert"
+				},
+				"emote_table": {
+					"emote_name": "Emote Name",
+					"uploader": "Ersteller",
+					"country": "Land",
+					"tags_flags": "Tags & Flags",
+					"reviewed_by": "Überprüft von"
+				},
+				"reports": "Meldungen",
+				"reports_options": {
+					"all": "Alle",
+					"assigned": "Zugewiesen",
+					"closed": "Geschlossen"
+				},
+				"reports_table": {
+					"reported_by": "Gemeldet von",
+					"target": "Ziel",
+					"description": "Beschreibung",
+					"assigned_to": "Zugewiesen an",
+					"status": "Status",
+					"date": "Datum",
+					"ticket_id": "Meldungs ID",
+					"subject": "Betreff",
+					"details": "Details"
+				},
+				"reports_actions": {
+					"close": "Als geschlossen markieren",
+					"assign_self": "Selbst zuweisen",
+					"add_comment": "Kommentar hinzufügen"
+				}
+			},
+			"codes": {
+				"redeem": "Codes einlösen",
+				"add": "Code(s) hinzufügen",
+				"filters": {
+					"header": "Filter:",
+					"remaining_uses": "Verbleibende Verwendungen"
+				},
+				"search": {
+					"results": "Es wurden {results.totalCount} Ergebnisse gefunden ({results.pageCount} Seiten)"
+				},
+				"attributes": {
+					"name": {
+						"name": "Name",
+						"description": "Beschreibung",
+						"tags": "Tags",
+						"code": "Code",
+						"remaining_uses": "Verbleibende Nutzungen",
+						"active_period": "Aktiver Zeitraum",
+						"effect": "Effekt",
+						"subscription_effect": "Abonnementeffekt",
+						"created_by": "Erstellt von",
+						"created_at": "Erstellt am",
+						"actions": "Aktionen"
+					}
+				},
+				"period": {
+					"unlimited": "Unendlich"
+				},
+				"trial": {
+					"days": "Tages Trial",
+					"no_trial": "Keine Testphase",
+					"none": "Keine"
+				},
+				"system": "System"
+			},
+			"special_events": {
+				"header": "Spezielle Events",
+				"create": "Besonderes Event erstellen",
+				"add": "Besonderes Event hinzufügen",
+				"results": "{results.length} Ergebnisse gefunden",
+				"attributes": {
+					"name": "Name",
+					"description": "Beschreibung",
+					"tags": "Tags",
+					"created_by": "Erstellt von",
+					"created_at": "Erstellt am",
+					"actions": "Aktionen",
+					"create": "Erstellen",
+					"cancel": "Abbrechen"
+				},
+				"system": "System",
+				"no_events": "Keine besonderen Events"
+			},
+			"users": {
+				"id": {
+					"back": "Zurück",
+					"last_updated": "Zuletzt aktualisiert um",
+					"search_last_update": "Suche zuletzt aktualisiert um",
+					"queued": "Für Update eingereiht",
+					"stripe": {
+						"customer": "Stripe Kunde",
+						"view": "Ansicht",
+						"no_customer": "Kein Stripe Kunde zugeordnet",
+						"roles": "Rollen"
+					},
+					"actions": {
+						"header": "Aktionen",
+						"sessions": {
+							"header": "Sitzungen",
+							"create_session": "Erstelle eine neue Sitzung",
+							"delete_all": "Lösche alle Sitzungen",
+							"expiration": "Läuft ab in",
+							"token": "Token",
+							"copy_token": "Kopier Token",
+							"create": "Erstellen",
+							"close": "Schließen"
+						},
+						"connections": {
+							"header": "Verknüpfungen",
+							"kick": "Verknüpfe Kick manuell",
+							"username": "Kick Benutzername"
+						},
+						"entitlements": {
+							"header": "Berechtigungen",
+							"create": "Berechtigungen erstellen",
+							"assign": "Berechtigungen manuell zuweisen",
+							"assign_to": "Berechtigungen zuweisen an",
+							"remove_all": "Alle Berechtigungen entfernen",
+							"view": "Berechtigungen anschauen",
+							"showing": "Anzeigen der zugewiesenen Berechtigungen für\n"
+						}
+					},
+					"subscription": {
+						"header": "Abonnement",
+						"period": {
+							"header": "Abonnementlaufzeiten",
+							"key": "Schlüssel",
+							"value": "Wert",
+							"id": "ID"
+						},
+						"copy": {
+							"ulid": "Kopiere ULID",
+							"uuid": "Kopiere UUID"
+						},
+						"provider": {
+							"id": "Anbieter ID",
+							"view": "Ansicht"
+						},
+						"product": {
+							"id": "Produkt ID",
+							"view": "Ansicht",
+							"start": "Start",
+							"end": "Ende",
+							"is_trial": "Ist Testphase?",
+							"auto_renew": "Automatische Erneuerung?",
+							"gifted": {
+								"header": "Geschenkt?",
+								"yes": "Ja, von",
+								"no": "Nein"
+							},
+							"created_by": "Erstellt von",
+							"redeem": "Code einlösen",
+							"invoice": "Rechnung",
+							"system": "System",
+							"variant": "Produkt Variante"
+						}
+					},
+					"not_found": "Benutzer nicht gefunden"
+				},
+				"layout": {
+					"users": "Benutzer"
+				},
+				"page": {
+					"manage": {
+						"header": "Verwalten",
+						"single_user": "Verwalte einen Nutzer"
+					},
+					"actions": {
+						"header": "Aktionen",
+						"sub_benefits_job": {
+							"header": "Vorteile des Abonnements",
+							"manually": "Führe den Abonnementvorgang manuell aus, um die Berechtigungen und Vorteile für alle Benutzer neu zu berechnen.",
+							"rerun": "Wiederholen"
+						}
+					}
+				}
+			}
+		},
+		"emote": {
+			"use_emote": "Emote nutzen",
+			"add_to": "Hinzufügen zu...",
+			"transfer": "Übertragen",
+			"merge": "Zusammenfügen",
+			"size": "Größe",
+			"copy_link": "Link kopieren",
+			"info": {
+				"used_by_channels": "Kanäle, die dieses Emote nutzen",
+				"channels_tooltip": "Anzahl der Kanäle, die dieses Emote aktuell in einem ihrer Emote-Sets aktiv gesetzt haben.",
+				"trending_this_week": "Trending-Rang diese Woche",
+				"trending_tooltip": "Position unter den Top ~500 Emotes von 7TV nach aktuellem Wachstum.",
+				"top_all_time": "Top-Rang aller Zeiten",
+				"top_all_time_tooltip": "Position unter den Top ~500 Emotes von 7TV nach gesamter Netto-Kanalverbreitung.",
+				"not_ranked": "Aktuell nicht gerankt",
+				"raw_score": "Wachstums-Score: {score}",
+				"stats_error": "Kanal-/Ranking-Statistiken konnten nicht geladen werden.",
+				"usage_note": "7TV erfasst nicht, wie oft ein Emote tatsächlich im Chat gesendet wird. Die Zahlen oben zeigen, wie viele Kanäle dieses Emote hinzugefügt haben und wie es in den Trending-/Top-Listen von 7TV abschneidet."
+			}
+		},
+		"user": {
+			"about": "Über",
+			"active_emotes": "Aktive Emotes",
+			"uploaded": "Hochgeladen",
+			"uploaded_emotes": "Hochgeladene Emotes"
+		},
+		"settings": {
+			"account": {
+				"title": "Konto",
+				"profile": {
+					"details": "Passe deine Präferenzen an und stelle Details entsprechend deiner individuellen Ansprüche ein",
+					"display_name": "Anzeigename",
+					"display_name_description": "Wähle eine Hauptverbindung, die für deinen Anzeigenamen und dein statisches Profilbild verwendet wird",
+					"profile_picture_description": "Wähle ein Profilbild aus, das auf allen Plattformen angezeigt wird",
+					"update_profile_picture": "Profilbild aktualisieren"
+				},
+				"connections": {
+					"details": "Verknüpfe und verwalte externe Konten, um den Zugriff zu optimieren und die Kompatibilität innerhalb der Plattform zu verbessern"
+				},
+				"security": {
+					"title": "Sicherheit",
+					"details": "Verwalte deine Konto-Sicherheit",
+					"2fa": "Zwei-Faktor-Authentifizierung",
+					"2fa_details": "Erhöhe die Sicherheit deines Kontos mit der Zwei-Faktor-Authentifizierung (2FA)",
+					"email_details": "Erhalte einen Bestätigungscode per E-Mail",
+					"authenticator_app": "Authentifizierungs App",
+					"authenticator_app_details": "Installiere eine App, um deinen Bestätigungscode zu generieren",
+					"sign_out_everywhere": "Überall abmelden",
+					"sign_out_everywhere_details": "Sorge für Sicherheit, indem du dich mit einem einzigen Klick von allen Geräten abmeldest",
+					"delete_account_details": "Entferne dauerhaft alle persönlichen Informationen und zugehörigen Daten von der Plattform und lösche dein Konto"
+				}
+			},
+			"appearance": {
+				"title": "Erscheinungsbild",
+				"details": "Verändere dein Erscheinungsbild",
+				"theme": {
+					"header": "Design",
+					"options": {
+						"system": "System",
+						"dark": "Dunkel",
+						"light": "Hell"
+					}
+				},
+				"motion": {
+					"header": "Reduzierte Bewegung",
+					"options": {
+						"system": "System",
+						"enabled": "Aktiviert",
+						"disbaled": "Deaktiviert"
+					}
+				},
+				"right-to-left-layout": {
+					"header": "Richtung des Website Layouts",
+					"options": {
+						"ltr": "Links nach rechts",
+						"rtl": "Rechts nach links"
+					}
+				}
+			},
+			"editors": {
+				"details": "Verwalte und passe deine Editoren oder Kanäle an, die du selbst bearbeitest",
+				"editing_for": "Editor für",
+				"add_editor": "Editor hinzufügen",
+				"not_allowed": "Es ist dir nicht erlaubt Editoren für diesen Benutzer zu verwalten"
+			},
+			"notifications": {
+				"details": "Echtzeit-Updates und Warnungen, die Benutzer über wichtige Ereignisse, Nachrichten und Aktivitäten auf der Website oder Anwendung informiert halten"
+			},
+			"blocked": {
+				"title": "Blockiert",
+				"details": "Verwalte deine eingeschränkten oder verbotenen Inhalte, Benutzer oder Aktivitäten",
+				"add_user": "Blockierten Nutzer hinzufügen"
+			},
+			"billing": {
+				"title": "Rechnungsbeleg",
+				"subscription": {
+					"details": "Lorem ipsum dolor sit, amet consectetur adipisicing elit. Magni incidunt numquam itaque, amet ad, pariatur possimus illo atque sunt asperiores molestias autem ex nobis consequuntur culpa. Corporis possimus aspernatur soluta.",
+					"use_credits": "Abo-Credits verwenden",
+					"use_credits_details": "Deine Abo-Credits werden für die nächste Abrechnung bevorzugt verwendet",
+					"cancelled": "Abonnement gekündigt",
+					"cancelled_details": "Dein Abonnement wurde gekündigt und deine Vorteile verfallen am {date}"
+				},
+				"history": {
+					"title": "Rechnungsverlauf",
+					"details": "Alle mit deinem Konto verbundenen Zahlungsaktivitäten einsehen, z. B. frühere Abrechnungen und Transaktionen"
+				},
+				"payment_methods": {
+					"details": "Prüfe und aktualisiere deine bevorzugten Zahlungsmethoden",
+					"add_new": "Neue hinzufügen",
+					"card": {
+						"title": "Kreditkarteninformationen",
+						"ends_in": "Endet mit {digits}",
+						"expires": "Läuft ab am {month}/{year}",
+						"address": "Adresse",
+						"name": "Name"
+					}
+				},
+				"table": {
+					"status": "Status",
+					"amount": "Menge",
+					"invoice": "Rechnung"
+				}
+			},
+			"user_table": {
+				"name": "Name",
+				"last_modified": "Zuletzt geändert",
+				"permissions": "Berechtigungen"
+			}
+		},
+		"link": {
+			"linking": "Konto wird verknüpft...",
+			"linking_successful": "Konto erfolgreich verknüpft",
+			"linking_failed": "Verknüpfung fehlgeschlagen"
+		},
+		"extension": {
+			"login": "Anmeldung läuft...",
+			"login_successful": "Angemeldet",
+			"login_failed": "Fehler beim Anmelden",
+			"window": "Stelle sicher, dass du dieses Fenster über die Erweiterung öffnest"
+		}
+	}
 }

--- a/apps/website/src/locales/en-GB.json
+++ b/apps/website/src/locales/en-GB.json
@@ -1,1028 +1,1041 @@
 {
-  "page_titles": {
-    "suffix": "7TV",
-    "admin_suffix": "7TV Admin",
-    "trending_emotes": "Trending Emotes",
-    "top_emotes": "Top Emotes",
-    "global_emotes": "Global Emotes",
-    "new_emotes": "New Emotes",
-    "bookmarked_emotes": "Bookmarked Emotes",
-    "bookmarked_emote_sets": "Bookmarked Emote Sets",
-    "bookmarked_users": "Bookmarked Users",
-    "account_settings": "Account Settings",
-    "editor_settings": "Editor Settings",
-    "notification_settings": "Notification Settings",
-    "blocked_settings": "Blocked Settings",
-    "billing_settings": "Billing Settings",
-    "admin_emote_public_listing": "Emote Public Listing Requests",
-    "admin_emote_personal_use": "Emote Personal Use Requests",
-    "admin_emote_resolved": "Resolved Emote Tickets"
-  },
-  "page_errors": {
-    "not_found": "The page you were looking for could not be found.",
-    "forbidden": "You do not have permission to view this page.",
-    "unauthorized": "You are unauthorised to view this page.",
-    "unexpected": "You can try refreshing the page. If the problem persists, please contact us.",
-    "generic": "An error occurred.",
-    "emote_set_load": "Failed to load emote set",
-    "emote_set_not_found": "Emote set not found",
-    "user": "Failed to load user"
-  },
-  "words": {
-    "from": "from",
-    "to": "to",
-    "with": "with",
-    "by": "by"
-  },
-  "common": {
-    "sign_in": "Sign In",
-    "sign_out": "Sign Out",
-    "go_back": "Go Back",
-    "super_admin": "Super Admin",
-    "skip_to_content": "Skip to content",
-    "emotes": "{count, plural, one {Emote} other {Emotes}}",
-    "emote_sets": "{count, plural, one {Emote Set} other {Emote Sets}}",
-    "users": "{count, plural, one {User} other {Users}}",
-    "channels": "{count, plural, one {Channel} other {Channels}}",
-    "followers": "{count, plural, one {Follower} other {Followers}}",
-    "items": "{count, plural, one {Item} other {Items}}",
-    "subscriptions": "{count, plural, one {Subscription} other {Subscriptions}}",
-    "payment_methods": "{count, plural, one {Payment Method} other {Payment Methods}}",
-    "date": "Date",
-    "help": "Help",
-    "for": "for",
-    "error": "Error",
-    "loading": "Loading...",
-    "paint_bundles": "Paint Bundles",
-    "notifications": "Notifications",
-    "connections": "Connections",
-    "direct_messages": "Direct Messages",
-    "mod_comments": "Mod Comments",
-    "profile_picture": "Profile Picture",
-    "suggested_emotes": "Suggested Emotes",
-    "personal_emotes": "Personal Emotes",
-    "no_more_emotes": "No more emotes",
-    "no_emotes": "No emotes",
-    "your_subscription": "Your Subscription",
-    "theme": "Theme",
-    "language": "Language",
-    "developer_portal": "Developer Portal",
-    "faq": "Frequently Asked Questions",
-    "faq_short": "FAQ",
-    "privacy": "Privacy Policy",
-    "tos": "Terms of Service",
-    "trending": "Trending",
-    "top": "Top",
-    "global": "Global",
-    "new": "New",
-    "Weekly": "Weekly",
-    "Monthly": "Monthly",
-    "Today": "Today",
-    "news": "News",
-    "Default_set": "Default Set",
-    "following": "Following",
-    "activity": "Activity",
-    "analytics": "Analytics",
-    "statistics": "Statistics",
-    "contact": "Contact",
-    "cosmetics": "Cosmetics",
-    "editors": "Editors",
-    "active": "Active",
-    "profile": "Profile",
-    "pinned": "Pinned",
-    "settings": "Settings",
-    "delete_account": "Delete Account"
-  },
-  "labels": {
-    "enter_text": "Enter text",
-    "redeem": "Enter code",
-    "search": "Search",
-    "refetch": "Refetch",
-    "manage_connections": "Manage Connections",
-    "manage_editors": "Manage Editors",
-    "none": "None",
-    "search_user": "Search User",
-    "search_country": "Search Country",
-    "search_emote_set": "Search Emote Set",
-    "search_users": "{count, plural, one {Search a user} other {Search users}}",
-    "tags": "Tags",
-    "close": "Close",
-    "contribute": "Contribute",
-    "enter_tags": "Enter tags",
-    "tag_limit_reached": "Tag limit of {limit} reached",
-    "filters": "Filters",
-    "no_filters": "No Filters",
-    "emote_name": "Emote Name",
-    "copy_link": "Copy Link",
-    "create_emote_set": "Create New Set",
-    "emote_set_name": "Emote Set Name",
-    "emote_attribution": "Emote Attribution",
-    "select": "Select",
-    "selection_mode": "Selection Mode",
-    "edit": "Edit",
-    "capacity": "Capacity",
-    "enable": "Enable",
-    "disable": "Disable",
-    "disabled": "Disabled",
-    "more": "More",
-    "actions": "Actions",
-    "download": "Download",
-    "report": "Report",
-    "delete": "Delete",
-    "time_select": {
-      "week": "This Week",
-      "month": "This Month",
-      "year": "This Year"
-    },
-    "gift": "Gift",
-    "follow": "Follow",
-    "connect": "Connect",
-    "disconnect": "Disconnect",
-    "email": "Email",
-    "password": "Password",
-    "all": "All",
-    "other": "Other",
-    "cancel": "Cancel",
-    "confirm": "Confirm",
-    "proceed": "Proceed",
-    "save": "Save",
-    "remove": "Remove",
-    "accept": "Accept",
-    "deny": "Deny",
-    "enter": "Enter"
-  },
-  "themes": {
-    "system": "System",
-    "dark": "Dark",
-    "light": "Light"
-  },
-  "flags": {
-    "global": "Global",
-    "trending": "Trending",
-    "overlaying": "Overlaying",
-    "default": "Default",
-    "personal": "Personal",
-    "listed": "Listed",
-    "unlisted": "Unlisted",
-    "personal_use": "Personal Use",
-    "deleted": "Deleted",
-    "private": "Private",
-    "personal_use_approved": "Approved Personal Use",
-    "personal_use_denied": "Denied Personal Use",
-    "personal_use_pending": "Personal Use Pending Review",
-    "renamed": "Renamed",
-    "nsfw": "NSFW",
-    "editor_flags": {
-      "pending": "Pending",
-      "accepted": "Accepted",
-      "rejected": "Rejected",
-      "you_accepted": "You Accepted",
-      "you_rejected": "You Rejected"
-    }
-  },
-  "notifications": {
-    "system": "System",
-    "approved_for_public": "Your emote {emote} has been approved for public listing."
-  },
-  "sub_info": {
-    "plan": "Plan",
-    "free": "Free",
-    "gifted_by": "Gifted by",
-    "ends": "Sub Ends",
-    "total": "Total",
-    "credits": "Sub Credits"
-  },
-  "file_limits": {
-    "max_size": "{size} max file size",
-    "max_resolution": "{width}x{height} max resolution",
-    "max_frames": "{count} max frames",
-    "resolution_error": "Resolution must not exceed {width}x{height}",
-    "duration_error": "Duration must be {duration} seconds or less"
-  },
-  "dialogs": {
-    "sign_in": {
-      "title": "Sign in to 7TV",
-      "subtitle": "Sign in or create an account to continue",
-      "continue_with": "Continue with {platform}",
-      "trouble": "Trouble signing in?",
-      "legal_yapping": "By signing in, you agree to our",
-      "and": "and",
-      "linking_new": "Already have a 7TV account and plan on linking a new connection? Sign in with your existing connection and link the new one in the",
-      "settings": "settings"
-    },
-    "search": {
-      "emotes": "Emotes",
-      "users": "Users"
-    },
-    "upload": {
-      "title": "Upload Emote",
-      "untitled": "Untitled",
-      "chat": "Send a message",
-      "drag_drop": "Drag & Drop to upload, or",
-      "browse_files": "Browse Files",
-      "accept_rules": "I accept the rules and guidelines",
-      "discard": "Discard",
-      "upload_guidelines": "Emote Upload Guidelines",
-      "upload": "Upload"
-    },
-    "emote_set": {
-      "title": "Active Emote Set",
-      "create": "Create Emote Set",
-      "name": "Emote Set Name",
-      "label": "Name",
-      "confirm": "Create",
-      "copy_set": "Copy Set",
-      "special": "Special",
-      "favourite_sets": {
-        "title": "Favourite Emote Sets",
-        "add": "Add & Rename to all",
-        "remove": "Remove from all"
-      },
-      "mass_select_feature": {
-        "add": "Add to Emote-Set",
-        "remove": "Remove from Emote-Set",
-        "amount_selected_label": "/20 Selected"
-      },
-      "default_emote_set": {
-        "remove": "Remove Emote from {set}",
-        "add": "Add Emote to {set}",
-        "conflicting_name": "Conflicting Name"
-      }
-    },
-    "manage_aliases": {
-      "title": "Manage Emote Aliases",
-      "add_placeholder": "Add new alias.."
-    },
-    "rename_emote": {
-      "title": "Rename Emote in {set}",
-      "input_placeholder": "New emote name",
-      "confirmation_message": "Are you sure you want to rename this emote in {set}?",
-      "confirm": "Rename"
-    },
-    "remove_emote_from_set": {
-      "title": "Remove Emote from {set}",
-      "warning_message": "Are you sure you want to remove {emote} from {set}?",
-      "confirm": "Remove"
-    },
-    "add_emote": {
-      "title": "Add {emote} to",
-      "change_name": "Change emote name",
-      "confirm": "Confirm",
-      "confirm_changes": "{count, plural, one {Confirm 1 change} other {Confirm {count} changes}}"
-    },
-    "emote_ticket": {
-      "emote_queue": "Emote queue",
-      "activity": "Activity",
-      "comments": "Comments"
-    },
-    "emote_context_menu": {
-      "add_remove_emote": "Add/Remove Emote",
-      "edit_emote_alias": "Edit Emote Alias",
-      "remove_emote": "Remove Emote From Set",
-      "open_in_new_tab": "Open in New Tab",
-      "copy_emote_link": "Copy Emote Link"
-    },
-    "cart": {
-      "title": "Your Cart",
-      "duration": "Duration",
-      "price": "Price",
-      "preview": "Preview",
-      "purchase_as_gift": "Purchase as a gift",
-      "total": "Total"
-    },
-    "editor": {
-      "permissions": "Set Editor Permissions",
-      "super_admin": "Super Admin",
-      "emote_sets": "Emote Sets",
-      "admin": "Admin",
-      "emotes": "Emotes",
-      "user": "User",
-      "manage_personal_emotes": "Manage Personal Emote Set",
-      "confirm": "Confirm",
-      "no_editors": "No editors to show",
-      "permissions_details": {
-        "manage": "Manage",
-        "create": "Create",
-        "transfer": "Transfer",
-        "manage_profile": "Manage Profile",
-        "manage_emotes": "Manage Emotes",
-        "manage_billing": "Manage Billing",
-        "manage_editors": "Manage Editors",
-        "view_billing": "View Billing Information"
-      }
-    },
-    "emote_info": {
-      "processing": "This emote is still processing",
-      "refresh": "Refresh",
-      "download": "Download"
-    },
-    "copy_emotes": {
-      "title": "Copy selected emotes to"
-    },
-    "default_set": {
-      "title": "Default Emote Set"
-    },
-    "delete_account": {
-      "warning": "Warning",
-      "warning_message": "This action will delete your account permanently. You cannot undo this action.",
-      "choose_reasons": "Choose the reasons for account deletion",
-      "reasons": {
-        "no_longer_use": "I no longer use 7TV",
-        "privacy_concerns": "Privacy concerns",
-        "not_useful": "Not useful",
-        "other": "Other"
-      },
-      "confirm_username": "Enter your username to confirm"
-    },
-    "delete_emote_or_set": {
-      "title": "Delete {name}",
-      "warning_message_emote": "This will delete your emote permanently. You cannot undo this action.",
-      "warning_message_set": "This will delete your emote set permanently. You cannot undo this action.",
-      "reason": "Reason",
-      "reason_for_deletion": "Reason for deletion"
-    },
-    "edit_emote": {
-      "title": "Edit {emote}"
-    },
-    "edit_emote_set": {
-      "title": "Edit Emote Set",
-      "show_on_profile": "Show on Profile",
-      "publicly_listed": "Publicly Listed"
-    },
-    "remove_emote": {
-      "title": "Remove selected emotes from {set}"
-    },
-    "report_emote": {
-      "title": "Report Emote",
-      "choose_reasons": "Choose the reasons",
-      "reasons": {
-        "my_work": "I made this emote but it was uploaded by someone else",
-        "duplicate": "This emote is a duplicate",
-        "sexual": "This emote contains pornographic or overly sexualised imagery",
-        "violance": "This emote displays extreme violence or gore",
-        "its_me": "This emote depicts me and I don't like it",
-        "offensive": "I find this emote offensive",
-        "other": "Other"
-      },
-      "additional_info": "Additional Information",
-      "disclaimer": "Abuse of the report feature may lead to your access being revoked."
-    },
-    "transfer_emote": {
-      "title": "Transfer {emote}",
-      "details": "This will transfer {emote}.",
-      "receipient": "Emote Receipient",
-      "transfer": "Transfer"
-    },
-    "badge": {
-      "title": "Badge"
-    },
-    "subscription": {
-      "gifted_by": "Your subscription was gifted to you by",
-      "cancel_notice": "Ending your subscription now will make you lose access to your subscription benefits immediately. Are you sure you want to end your subscription?",
-      "cancel_confirmation": "Are you sure you want to cancel your subscription? You will lose access to your subscription benefits at the end of your current billing period.",
-      "confirm": "Confirm"
-    },
-    "error": {
-      "title": "Error"
-    },
-    "pickems": {
-      "gift": {
-        "title": "Gift Pick'ems Pass",
-        "gift_to": "Gift Pick'ems Pass to",
-        "recipient": "Select recipient",
-        "back": "Back",
-        "continue": "Continue"
-      }
-    },
-    "gift": {
-      "title": "Gift 1",
-      "gift_to": "Gift 1 {variantUnit(variant)} to",
-      "recipient": "Select recipient"
-    },
-    "paint": {
-      "title": "Paint"
-    },
-    "buttons": {
-      "back": "Back",
-      "continue": "Continue"
-    },
-    "emote-events": {
-      "upload": {
-        "action": "Uploaded"
-      },
-      "process": {
-        "start": "Started a new processing job",
-        "success": "Successfully finished processing",
-        "fail": "Failed processing",
-        "cancel": "Cancelled processing job"
-      },
-      "change_name": {
-        "action": "Renamed"
-      },
-      "merge": {
-        "action": "Merged"
-      },
-      "change_owner": {
-        "action": "Transferred ownership"
-      },
-      "change_tags": {
-        "action": "Set tags to"
-      },
-      "change_flags": {
-        "approved_public": {
-          "action": "Approved for public listing"
-        },
-        "removed_public": {
-          "action": "Removed from public listing"
-        },
-        "approved_personal": {
-          "action": "Approved for personal use"
-        },
-        "rejected_personal": {
-          "action": "Rejected for personal use"
-        },
-        "added_overlaying": {
-          "action": "Added flag overlaying"
-        },
-        "removed_overlaying": {
-          "action": "Removed flag overlaying"
-        },
-        "added_private": {
-          "action": "Added flag private"
-        },
-        "removed_private": {
-          "action": "Removed flag private"
-        }
-      },
-      "delete": {
-        "action": "Deleted"
-      }
-    }
-  },
-  "pages": {
-    "activity": {
-      "title": "Activity",
-      "emote": {
-        "deleted_emote": "Deleted Emote",
-        "deleted_set": "Deleted Set",
-        "by": "by",
-        "created": "Created",
-        "changed_tags": "Changed tags for",
-        "changed_capacity": "Changed capacity for",
-        "added": "Added",
-        "removed": "Removed emote",
-        "renamed": "Renamed emote",
-        "in": "in",
-        "from": "from",
-        "to": "to",
-        "deleted": "Deleted"
-      },
-      "user": {
-        "changed_paint": "Changed active paint from",
-        "changed_badge": "Changed active badge from",
-        "removed": "Removed",
-        "connection": "Connection",
-        "changed_set": "Changed active emote set from",
-        "added": "Added",
-        "no_badge": "No Badge",
-        "no_paint": "No Paint",
-        "deleted": "Deleted"
-      }
-    },
-    "auth": {
-      "title": {
-        "logging": "Logging you in...",
-        "logged": "Logged in",
-        "failed": "Failed to log in"
-      },
-      "state": {
-        "logging": "Logging you in...",
-        "logged": "Logged in",
-        "failed": {
-          "title": "Login Failed",
-          "message": "Make sure to open this window through the extension"
-        }
-      }
-    },
-    "home": {
-      "title": "Home",
-      "features": {
-        "emote_slots": "1000 Emote Slots",
-        "emote_slots_info": "Everyone gets 1000 customisable channel emote slots, all for free. Keep all your emotes in one place.",
-        "emote_slots_button": "Browse Emotes",
-        "emote_sets": "Emote Sets",
-        "emote_sets_info": "Group emotes in customisable sets that can be shared with other users or quickly swapped onto your channel.",
-        "emote_sets_button": "Create an Emote Set",
-        "custom_emotes": "Custom Emote Names",
-        "custom_emotes_info": "Don't like the name given to an emote by its author? That's fine, you can change it for your channel only.",
-        "custom_emotes_button": "Browse Emotes",
-        "real-time": "Real-Time Updates",
-        "real-time_info": "Changing emotes in your channel happens instantly, for all viewers. No F5 required, no more waiting.",
-        "real-time_button": "Download the Extension",
-        "large_community": "Large Community",
-        "large_community_info": "7TV serves 2,000,000+ daily unique users and has a library of over 1,000,000 public emotes.",
-        "large_community_button": "Join our Discord",
-        "next_gen": "Next-gen Formats",
-        "next_gen_info": "We use newer, more optimised image formats like WebP and AVIF, to reduce bandwidth usage.",
-        "next_gen_button": "Download the Extension"
-      }
-    },
-    "help": {
-      "title": "Help"
-    },
-    "directory": {
-      "title": "Directory",
-      "bookmarked": "Bookmarked",
-      "sorting": {
-        "title": "Sorting",
-        "alphabetical": "Alphabetical",
-        "upload_date": "Upload Date"
-      },
-      "filters": {
-        "animated": "Animated",
-        "static": "Static",
-        "overlaying": "Overlaying",
-        "personal_use": "Personal Use",
-        "exact_match": "Exact Match"
-      },
-      "size": {
-        "title": "Size",
-        "any": "Any Size"
-      }
-    },
-    "landing": {
-      "start": "Start your journey with hundreds of emotes and features that enhance your chatting experience. Download the Official 7TV Extension or other 3rd party tools.",
-      "developers": {
-        "header": "Source-Available",
-        "info": "Our entire codebase is available on GitHub with a source-available licence. Anyone can view and contribute."
-      },
-      "download": {
-        "start": "Start your journey with hundreds of emotes and features that enhance your chatting experience. Download the Official 7TV Extension or other 3rd party tools.",
-        "extension": "Web Extension",
-        "recommended": "Recommended",
-        "stable": "Stable Release",
-        "nightly": "Nightly Release",
-        "chatterino": "Chatterino",
-        "mobile": {
-          "apps": "Mobile Apps"
-        },
-        "bots": {
-          "header": "Chat Bots"
-        }
-      },
-      "features": {
-        "header": "Why 7TV?",
-        "info": "Our platform offers a variety of useful features that will enhance your chatting experience."
-      },
-      "footer": {
-        "affiliated": "7TV is not affiliated with Twitch, Kick or Discord",
-        "privacy_policy": "Privacy Policy",
-        "tos": "Terms of Service"
-      },
-      "hero": {
-        "platform": "The Emote Platform",
-        "all": "for All",
-        "download": "Download",
-        "manage": "Manage hundreds of emotes for your Twitch and sKick channels with ease. Enhance your chatting experience.",
-        "more": "Learn more",
-        "xmas": {
-          "header": "X-MAS SUB EVENT",
-          "info": "Gift 1 sub to anyone this christmas and get a special badge!",
-          "gift": "Gift a sub"
-        },
-        "nnys": {
-          "info": "Vote on NNYS 2025 to get an exclusive paint, badge & emote set.",
-          "vote": "Vote in NNYS 2025"
-        },
-        "cs2": {
-          "streamers": "35 STREAMERS",
-          "tournament": "7TV HOSTED TOURNAMENT",
-          "event": "3 DAY EVENT",
-          "header": "Place your Pick'ems. Win Prizes.",
-          "info": "7TV Hoster CS2 Tournament",
-          "date": "Feb. 29th - Mar. 2nd",
-          "pickems": "Place your pick'ems",
-          "pass": "Get the pass!",
-          "badges_paints": "Win Badges & Paints.",
-          "description1": "xQc, OhnePixel, JasonTheWeen and 32 other streamers go head to head",
-          "description2": "in a 3-day Single Elimination 7TV Hosted CS2 tournament."
-        }
-      }
-    },
-    "discover": {
-      "title": "Discover",
-      "uploads": "Uploads",
-      "followed": "Followed accounts"
-    },
-    "store": {
-      "title": "Store",
-      "redeem": {
-        "title": "Redeem",
-        "header": "Redeem a Gift Code",
-        "subtitle": "Redeem a gift code to unlock exclusive cosmetics and benefits.",
-        "state": {
-          "idle": "Idle",
-          "loading": "Loading",
-          "success": "Success"
-        },
-        "code": "code",
-        "shown": "shown",
-        "trial": "You successfully redeemed your trial subscription"
-      },
-      "purchase": {
-        "success": "Your purchase was successfully completed"
-      },
-      "subscription": {
-        "banner_title_subbed": "Thank You For the Support",
-        "banner_title_unsubbed": "Unlock Special Perks",
-        "banner_subtitle_subbed": "Enjoy Your Special Subscriber Perks!",
-        "banner_subtitle_unsubbed": "Subscribe to Enhance Your Chatting Experience.",
-        "badge_progress": {
-          "title": "Badge Progress",
-          "left": "{duration} left"
-        },
-        "benefits": {
-          "title": "Subscription Benefits",
-          "animated_avatar": "Animated Profile Picture",
-          "personal_emotes": "Personal Emotes",
-          "paints": "Nametag Paints",
-          "sub_badge": "Subscriber Badge",
-          "raffle_tickets": "Raffle Tickets"
-        },
-        "raffle": "Global Emote Raffle",
-        "monthly_paints": "Monthly Paints",
-        "your_cosmetics": "Your Cosmetics",
-        "your_paints": "Your Paints",
-        "beomce_a_subscriber": "Become a Subscriber",
-        "your_badges": "Your Badges",
-        "top_gifters": "Top Gifters",
-        "subscribe": "Subscribe",
-        "subscribed": "Subscribed",
-        "cancel": "Cancel Subscription",
-        "reactivate": "Reactivate Subscription",
-        "one_monhth": "1 Month",
-        "one_year": "1 Year"
-      },
-      "paint_bundles": {
-        "coming_soon": "Coming Soon",
-        "banner_title": "Make Yourself Glow",
-        "banner_subtitle": "Nametag Paints Will Let You Express Yourself in Every Hue."
-      },
-      "events": {
-        "no_events": "No upcoming events",
-        "xmas": "X-MAS 2024 EVENT: GIFT 1 SUB TO GET A SPECIAL BADGE",
-        "cs2": {
-          "tournament": "7TV Hosted CS2 Tournament",
-          "cosmetics": "Want to earn cosmetics for predicting the outcome? Click below!",
-          "twitch": "VIEW TWITCH",
-          "bundle": "Purchase Bundle",
-          "already_subscribed": "Already Subscribed",
-          "subscribe": "{price} today, then {recurring}",
-          "billing_cycle": "Billed as one-time purchase",
-          "pickems": {
-            "place": "Place Pick'ems",
-            "predict": "Predict Winners",
-            "purchase_pass": "Purchase Pass"
-          },
-          "pass": {
-            "title": "Pick'ems Pass",
-            "get": "Get Pass",
-            "bundle": "Pass + {variantName(variant)} Subscription Bundle"
-          },
-          "schedule": {
-            "header": "Tournament Schedule",
-            "stage": "Stage",
-            "best_of": "Best of",
-            "start_time": "Start Time"
-          },
-          "streamers": {
-            "header": "Meet the Streamers",
-            "info": "A prominent line-up of Twitch Streamers build a team from their communities who go head-to-head in a CS-Style Single Elimination Tournament.",
-            "watch": "Watch the main event on the",
-            "twitch_channel": "7TV Twitch Channel",
-            "streamer_pov": "or through your favourite streamer's POV."
-          }
-        }
-      }
-    },
-    "admin": {
-      "title": "Admin",
-      "overview": "Overview",
-      "welcome": "Welcome back",
-      "enjoy": "Enjoy modding!",
-      "tickets": {
-        "title": "Tickets",
-        "emotes": {
-          "public_listing": "Public Listing",
-          "personal_use": "Personal Use",
-          "resolved": "Resolved",
-          "not_implemented": "Not Implemented"
-        },
-        "emote_table": {
-          "emote_name": "Emote Name",
-          "uploader": "Uploader",
-          "country": "Country",
-          "tags_flags": "Tags & Flags",
-          "reviewed_by": "Reviewed By"
-        },
-        "reports": "Reports",
-        "reports_options": {
-          "all": "All",
-          "assigned": "Assigned",
-          "closed": "Closed"
-        },
-        "reports_table": {
-          "reported_by": "Reported by",
-          "target": "Target",
-          "description": "Description",
-          "assigned_to": "Assigned to",
-          "status": "Status",
-          "date": "Date",
-          "ticket_id": "Ticket ID",
-          "subject": "Subject",
-          "details": "Details"
-        },
-        "reports_actions": {
-          "close": "Mark as Closed",
-          "assign_self": "Assign Self",
-          "add_comment": "Add comment"
-        }
-      },
-      "codes": {
-        "redeem": "Redeem Codes",
-        "add": "Add Code(s)",
-        "filters": {
-          "header": "Filters:",
-          "remaining_uses": "Remaining Uses"
-        },
-        "search": {
-          "results": "Found {results.totalCount} results ({results.pageCount} pages)"
-        },
-        "attributes": {
-          "name": {
-            "name": "Name",
-            "description": "Description",
-            "tags": "Tags",
-            "code": "Code",
-            "remaining_uses": "Remaining Uses",
-            "active_period": "Active Period",
-            "effect": "Effect",
-            "subscription_effect": "Subscription Effect",
-            "created_by": "Created By",
-            "created_at": "Created At",
-            "actions": "Actions"
-          }
-        },
-        "period": {
-          "unlimited": "Unlimited"
-        },
-        "trial": {
-          "days": "days trial",
-          "no_trial": "No trial",
-          "none": "None"
-        },
-        "system": "System"
-      },
-      "special_events": {
-        "header": "Special Events",
-        "create": "Create Special Event",
-        "add": "Add Special Event",
-        "results": "Found {results.length} results",
-        "attributes": {
-          "name": "Name",
-          "description": "Description",
-          "tags": "Tags",
-          "created_by": "Created By",
-          "created_at": "Created At",
-          "actions": "Actions",
-          "create": "Create",
-          "cancel": "Cancel"
-        },
-        "system": "System",
-        "no_events": "No Special Events"
-      },
-      "users": {
-        "id": {
-          "back": "Back",
-          "last_updated": "Last Updated At",
-          "search_last_update": "Search Last Updated At",
-          "queued": "Queued for update",
-          "stripe": {
-            "customer": "Stripe Customer",
-            "view": "View",
-            "no_customer": "No stripe customer associated",
-            "roles": "Roles"
-          },
-          "actions": {
-            "header": "Actions",
-            "sessions": {
-              "header": "Sessions",
-              "create_session": "Create New Session",
-              "delete_all": "Delete All Sessions",
-              "expiration": "Expiration date in",
-              "token": "Token",
-              "copy_token": "Copy Token",
-              "create": "Create",
-              "close": "Close"
-            },
-            "connections": {
-              "header": "Connections",
-              "kick": "Manually Link Kick",
-              "username": "Kick Username"
-            },
-            "entitlements": {
-              "header": "Entitlements",
-              "create": "Create Entitlements",
-              "assign": "Manually Assign Entitlements",
-              "assign_to": "Assign entitlements to",
-              "remove_all": "Remove All Entitlements",
-              "view": "View Entitlements",
-              "showing": "Showing entitlements assigned to"
-            }
-          },
-          "subscription": {
-            "header": "Subscription",
-            "period": {
-              "header": "Subscription Periods",
-              "key": "Key",
-              "value": "Value",
-              "id": "ID"
-            },
-            "copy": {
-              "ulid": "Copy ULID",
-              "uuid": "Copy UUID"
-            },
-            "provider": {
-              "id": "Provider ID",
-              "view": "View"
-            },
-            "product": {
-              "id": "Product ID",
-              "view": "View",
-              "start": "Start",
-              "end": "End",
-              "is_trial": "Is Trial?",
-              "auto_renew": "Auto Renew?",
-              "gifted": {
-                "header": "Gifted?",
-                "yes": "Yes - By",
-                "no": "No"
-              },
-              "created_by": "Created By",
-              "redeem": "Redeem Code",
-              "invoice": "Invoice",
-              "system": "System",
-              "variant": "Product Variant"
-            }
-          },
-          "not_found": "User not found"
-        },
-        "layout": {
-          "users": "Users"
-        },
-        "page": {
-          "manage": {
-            "header": "Manage",
-            "single_user": "Manage a single user"
-          },
-          "actions": {
-            "header": "Actions",
-            "sub_benefits_job": {
-              "header": "Subscription Benefits Job",
-              "manually": "Manually trigger the subscription job to recalculate entitlements and subscription benefits for all users.",
-              "rerun": "Rerun"
-            }
-          }
-        }
-      }
-    },
-    "emote": {
-      "use_emote": "Use Emote",
-      "add_to": "Add to...",
-      "transfer": "Transfer",
-      "merge": "Merge",
-      "size": "Size",
-      "copy_link": "Copy Link"
-    },
-    "user": {
-      "about": "About",
-      "active_emotes": "Active Emotes",
-      "uploaded": "Uploaded",
-      "uploaded_emotes": "Uploaded Emotes"
-    },
-    "settings": {
-      "account": {
-        "title": "Account",
-        "profile": {
-          "details": "Customise preferences and manage details to suit your individual needs",
-          "display_name": "Display Name",
-          "display_name_description": "Choose a main connection that will be used for your display name and static profile picture",
-          "profile_picture_description": "Choose a profile picture that will be displayed on all platforms",
-          "update_profile_picture": "Update Profile Picture"
-        },
-        "connections": {
-          "details": "Manage and link external accounts to streamline access and enhance interoperability within the platform"
-        },
-        "security": {
-          "title": "Security",
-          "details": "Manage and customise your account security",
-          "2fa": "Two Factor Authentication",
-          "2fa_details": "Enhance the security of your account with Two-Factor Authentication (2FA)",
-          "email_details": "Receive a verification code via email",
-          "authenticator_app": "Authenticator App",
-          "authenticator_app_details": "Install an app to generate your verification code",
-          "sign_out_everywhere": "Sign Out Everywhere",
-          "sign_out_everywhere_details": "Ensure security and log out from all devices with a single click",
-          "delete_account_details": "Permanently remove all personal information and associated data from the platform, terminating your account"
-        }
-      },
-      "appearance": {
-        "title": "Appearance",
-        "details": "Change the look and feel",
-        "theme": {
-          "header": "Theme",
-          "options": {
-            "system": "System",
-            "dark": "Dark",
-            "light": "Light"
-          }
-        },
-        "motion": {
-          "header": "Reduced Motion",
-          "options": {
-            "system": "System",
-            "enabled": "Enabled",
-            "disbaled": "Disabled"
-          }
-        },
-        "right-to-left-layout": {
-          "header": "Website Direction Layout",
-          "options": {
-            "ltr": "Left to Right",
-            "rtl": "Right to Left"
-          }
-        }
-      },
-      "editors": {
-        "details": "Manage and customise your editors or channels your edit for",
-        "editing_for": "Editing For",
-        "add_editor": "Add Editor",
-        "not_allowed": "You are not allowed to manage editors for this user"
-      },
-      "notifications": {
-        "details": "Real-time updates and alerts, keeping users informed about important events, messages, and activities within the website or application"
-      },
-      "blocked": {
-        "title": "Blocked",
-        "details": "Manage your restricted or prohibited content, users, or activities",
-        "add_user": "Add Blocked User"
-      },
-      "billing": {
-        "title": "Billing",
-        "subscription": {
-          "details": "Lorem ipsum dolor sit, amet consectetur adipisicing elit. Magni incidunt numquam itaque, amet ad, pariatur possimus illo atque sunt asperiores molestias autem ex nobis consequuntur culpa. Corporis possimus aspernatur soluta.",
-          "use_credits": "Use Subscription Credits",
-          "use_credits_details": "Your subscription credits will be used first for your next billing",
-          "cancelled": "Subscription Cancelled",
-          "cancelled_details": "Your subscription has been cancelled and your benefits will expire on {date}"
-        },
-        "history": {
-          "title": "Billing History",
-          "details": "See all payment activities associated with your account, such as past billing statements and transactions"
-        },
-        "payment_methods": {
-          "details": "Check and update your preferred payment methods",
-          "add_new": "Add New",
-          "card": {
-            "title": "Card Info",
-            "ends_in": "Ends in {digits}",
-            "expires": "Expires {month}/{year}",
-            "address": "Address",
-            "name": "Name"
-          }
-        },
-        "table": {
-          "status": "Status",
-          "amount": "Amount",
-          "invoice": "Invoice"
-        }
-      },
-      "user_table": {
-        "name": "Name",
-        "last_modified": "Last Modified",
-        "permissions": "Permissions"
-      }
-    },
-    "link": {
-      "linking": "Linking Your Account...",
-      "linking_successful": "Account Successfully Linked",
-      "linking_failed": "Linking Failed"
-    },
-    "extension": {
-      "login": "Logging you in...",
-      "login_successful": "Logged in",
-      "login_failed": "Failed to log in",
-      "window": "Make sure to open this window through the extension"
-    }
-  }
+	"page_titles": {
+		"suffix": "7TV",
+		"admin_suffix": "7TV Admin",
+		"trending_emotes": "Trending Emotes",
+		"top_emotes": "Top Emotes",
+		"global_emotes": "Global Emotes",
+		"new_emotes": "New Emotes",
+		"bookmarked_emotes": "Bookmarked Emotes",
+		"bookmarked_emote_sets": "Bookmarked Emote Sets",
+		"bookmarked_users": "Bookmarked Users",
+		"account_settings": "Account Settings",
+		"editor_settings": "Editor Settings",
+		"notification_settings": "Notification Settings",
+		"blocked_settings": "Blocked Settings",
+		"billing_settings": "Billing Settings",
+		"admin_emote_public_listing": "Emote Public Listing Requests",
+		"admin_emote_personal_use": "Emote Personal Use Requests",
+		"admin_emote_resolved": "Resolved Emote Tickets"
+	},
+	"page_errors": {
+		"not_found": "The page you were looking for could not be found.",
+		"forbidden": "You do not have permission to view this page.",
+		"unauthorized": "You are unauthorised to view this page.",
+		"unexpected": "You can try refreshing the page. If the problem persists, please contact us.",
+		"generic": "An error occurred.",
+		"emote_set_load": "Failed to load emote set",
+		"emote_set_not_found": "Emote set not found",
+		"user": "Failed to load user"
+	},
+	"words": {
+		"from": "from",
+		"to": "to",
+		"with": "with",
+		"by": "by"
+	},
+	"common": {
+		"sign_in": "Sign In",
+		"sign_out": "Sign Out",
+		"go_back": "Go Back",
+		"super_admin": "Super Admin",
+		"skip_to_content": "Skip to content",
+		"emotes": "{count, plural, one {Emote} other {Emotes}}",
+		"emote_sets": "{count, plural, one {Emote Set} other {Emote Sets}}",
+		"users": "{count, plural, one {User} other {Users}}",
+		"channels": "{count, plural, one {Channel} other {Channels}}",
+		"followers": "{count, plural, one {Follower} other {Followers}}",
+		"items": "{count, plural, one {Item} other {Items}}",
+		"subscriptions": "{count, plural, one {Subscription} other {Subscriptions}}",
+		"payment_methods": "{count, plural, one {Payment Method} other {Payment Methods}}",
+		"date": "Date",
+		"help": "Help",
+		"for": "for",
+		"error": "Error",
+		"loading": "Loading...",
+		"paint_bundles": "Paint Bundles",
+		"notifications": "Notifications",
+		"connections": "Connections",
+		"direct_messages": "Direct Messages",
+		"mod_comments": "Mod Comments",
+		"profile_picture": "Profile Picture",
+		"suggested_emotes": "Suggested Emotes",
+		"personal_emotes": "Personal Emotes",
+		"no_more_emotes": "No more emotes",
+		"no_emotes": "No emotes",
+		"your_subscription": "Your Subscription",
+		"theme": "Theme",
+		"language": "Language",
+		"developer_portal": "Developer Portal",
+		"faq": "Frequently Asked Questions",
+		"faq_short": "FAQ",
+		"privacy": "Privacy Policy",
+		"tos": "Terms of Service",
+		"trending": "Trending",
+		"top": "Top",
+		"global": "Global",
+		"new": "New",
+		"Weekly": "Weekly",
+		"Monthly": "Monthly",
+		"Today": "Today",
+		"news": "News",
+		"Default_set": "Default Set",
+		"following": "Following",
+		"activity": "Activity",
+		"info": "Info",
+		"analytics": "Analytics",
+		"statistics": "Statistics",
+		"contact": "Contact",
+		"cosmetics": "Cosmetics",
+		"editors": "Editors",
+		"active": "Active",
+		"profile": "Profile",
+		"pinned": "Pinned",
+		"settings": "Settings",
+		"delete_account": "Delete Account"
+	},
+	"labels": {
+		"enter_text": "Enter text",
+		"redeem": "Enter code",
+		"search": "Search",
+		"refetch": "Refetch",
+		"manage_connections": "Manage Connections",
+		"manage_editors": "Manage Editors",
+		"none": "None",
+		"search_user": "Search User",
+		"search_country": "Search Country",
+		"search_emote_set": "Search Emote Set",
+		"search_users": "{count, plural, one {Search a user} other {Search users}}",
+		"tags": "Tags",
+		"close": "Close",
+		"contribute": "Contribute",
+		"enter_tags": "Enter tags",
+		"tag_limit_reached": "Tag limit of {limit} reached",
+		"filters": "Filters",
+		"no_filters": "No Filters",
+		"emote_name": "Emote Name",
+		"copy_link": "Copy Link",
+		"create_emote_set": "Create New Set",
+		"emote_set_name": "Emote Set Name",
+		"emote_attribution": "Emote Attribution",
+		"select": "Select",
+		"selection_mode": "Selection Mode",
+		"edit": "Edit",
+		"capacity": "Capacity",
+		"enable": "Enable",
+		"disable": "Disable",
+		"disabled": "Disabled",
+		"more": "More",
+		"actions": "Actions",
+		"download": "Download",
+		"report": "Report",
+		"delete": "Delete",
+		"time_select": {
+			"week": "This Week",
+			"month": "This Month",
+			"year": "This Year"
+		},
+		"gift": "Gift",
+		"follow": "Follow",
+		"connect": "Connect",
+		"disconnect": "Disconnect",
+		"email": "Email",
+		"password": "Password",
+		"all": "All",
+		"other": "Other",
+		"cancel": "Cancel",
+		"confirm": "Confirm",
+		"proceed": "Proceed",
+		"save": "Save",
+		"remove": "Remove",
+		"accept": "Accept",
+		"deny": "Deny",
+		"enter": "Enter"
+	},
+	"themes": {
+		"system": "System",
+		"dark": "Dark",
+		"light": "Light"
+	},
+	"flags": {
+		"global": "Global",
+		"trending": "Trending",
+		"overlaying": "Overlaying",
+		"default": "Default",
+		"personal": "Personal",
+		"listed": "Listed",
+		"unlisted": "Unlisted",
+		"personal_use": "Personal Use",
+		"deleted": "Deleted",
+		"private": "Private",
+		"personal_use_approved": "Approved Personal Use",
+		"personal_use_denied": "Denied Personal Use",
+		"personal_use_pending": "Personal Use Pending Review",
+		"renamed": "Renamed",
+		"nsfw": "NSFW",
+		"editor_flags": {
+			"pending": "Pending",
+			"accepted": "Accepted",
+			"rejected": "Rejected",
+			"you_accepted": "You Accepted",
+			"you_rejected": "You Rejected"
+		}
+	},
+	"notifications": {
+		"system": "System",
+		"approved_for_public": "Your emote {emote} has been approved for public listing."
+	},
+	"sub_info": {
+		"plan": "Plan",
+		"free": "Free",
+		"gifted_by": "Gifted by",
+		"ends": "Sub Ends",
+		"total": "Total",
+		"credits": "Sub Credits"
+	},
+	"file_limits": {
+		"max_size": "{size} max file size",
+		"max_resolution": "{width}x{height} max resolution",
+		"max_frames": "{count} max frames",
+		"resolution_error": "Resolution must not exceed {width}x{height}",
+		"duration_error": "Duration must be {duration} seconds or less"
+	},
+	"dialogs": {
+		"sign_in": {
+			"title": "Sign in to 7TV",
+			"subtitle": "Sign in or create an account to continue",
+			"continue_with": "Continue with {platform}",
+			"trouble": "Trouble signing in?",
+			"legal_yapping": "By signing in, you agree to our",
+			"and": "and",
+			"linking_new": "Already have a 7TV account and plan on linking a new connection? Sign in with your existing connection and link the new one in the",
+			"settings": "settings"
+		},
+		"search": {
+			"emotes": "Emotes",
+			"users": "Users"
+		},
+		"upload": {
+			"title": "Upload Emote",
+			"untitled": "Untitled",
+			"chat": "Send a message",
+			"drag_drop": "Drag & Drop to upload, or",
+			"browse_files": "Browse Files",
+			"accept_rules": "I accept the rules and guidelines",
+			"discard": "Discard",
+			"upload_guidelines": "Emote Upload Guidelines",
+			"upload": "Upload"
+		},
+		"emote_set": {
+			"title": "Active Emote Set",
+			"create": "Create Emote Set",
+			"name": "Emote Set Name",
+			"label": "Name",
+			"confirm": "Create",
+			"copy_set": "Copy Set",
+			"special": "Special",
+			"favourite_sets": {
+				"title": "Favourite Emote Sets",
+				"add": "Add & Rename to all",
+				"remove": "Remove from all"
+			},
+			"mass_select_feature": {
+				"add": "Add to Emote-Set",
+				"remove": "Remove from Emote-Set",
+				"amount_selected_label": "/20 Selected"
+			},
+			"default_emote_set": {
+				"remove": "Remove Emote from {set}",
+				"add": "Add Emote to {set}",
+				"conflicting_name": "Conflicting Name"
+			}
+		},
+		"manage_aliases": {
+			"title": "Manage Emote Aliases",
+			"add_placeholder": "Add new alias.."
+		},
+		"rename_emote": {
+			"title": "Rename Emote in {set}",
+			"input_placeholder": "New emote name",
+			"confirmation_message": "Are you sure you want to rename this emote in {set}?",
+			"confirm": "Rename"
+		},
+		"remove_emote_from_set": {
+			"title": "Remove Emote from {set}",
+			"warning_message": "Are you sure you want to remove {emote} from {set}?",
+			"confirm": "Remove"
+		},
+		"add_emote": {
+			"title": "Add {emote} to",
+			"change_name": "Change emote name",
+			"confirm": "Confirm",
+			"confirm_changes": "{count, plural, one {Confirm 1 change} other {Confirm {count} changes}}"
+		},
+		"emote_ticket": {
+			"emote_queue": "Emote queue",
+			"activity": "Activity",
+			"comments": "Comments"
+		},
+		"emote_context_menu": {
+			"add_remove_emote": "Add/Remove Emote",
+			"edit_emote_alias": "Edit Emote Alias",
+			"remove_emote": "Remove Emote From Set",
+			"open_in_new_tab": "Open in New Tab",
+			"copy_emote_link": "Copy Emote Link"
+		},
+		"cart": {
+			"title": "Your Cart",
+			"duration": "Duration",
+			"price": "Price",
+			"preview": "Preview",
+			"purchase_as_gift": "Purchase as a gift",
+			"total": "Total"
+		},
+		"editor": {
+			"permissions": "Set Editor Permissions",
+			"super_admin": "Super Admin",
+			"emote_sets": "Emote Sets",
+			"admin": "Admin",
+			"emotes": "Emotes",
+			"user": "User",
+			"manage_personal_emotes": "Manage Personal Emote Set",
+			"confirm": "Confirm",
+			"no_editors": "No editors to show",
+			"permissions_details": {
+				"manage": "Manage",
+				"create": "Create",
+				"transfer": "Transfer",
+				"manage_profile": "Manage Profile",
+				"manage_emotes": "Manage Emotes",
+				"manage_billing": "Manage Billing",
+				"manage_editors": "Manage Editors",
+				"view_billing": "View Billing Information"
+			}
+		},
+		"emote_info": {
+			"processing": "This emote is still processing",
+			"refresh": "Refresh",
+			"download": "Download"
+		},
+		"copy_emotes": {
+			"title": "Copy selected emotes to"
+		},
+		"default_set": {
+			"title": "Default Emote Set"
+		},
+		"delete_account": {
+			"warning": "Warning",
+			"warning_message": "This action will delete your account permanently. You cannot undo this action.",
+			"choose_reasons": "Choose the reasons for account deletion",
+			"reasons": {
+				"no_longer_use": "I no longer use 7TV",
+				"privacy_concerns": "Privacy concerns",
+				"not_useful": "Not useful",
+				"other": "Other"
+			},
+			"confirm_username": "Enter your username to confirm"
+		},
+		"delete_emote_or_set": {
+			"title": "Delete {name}",
+			"warning_message_emote": "This will delete your emote permanently. You cannot undo this action.",
+			"warning_message_set": "This will delete your emote set permanently. You cannot undo this action.",
+			"reason": "Reason",
+			"reason_for_deletion": "Reason for deletion"
+		},
+		"edit_emote": {
+			"title": "Edit {emote}"
+		},
+		"edit_emote_set": {
+			"title": "Edit Emote Set",
+			"show_on_profile": "Show on Profile",
+			"publicly_listed": "Publicly Listed"
+		},
+		"remove_emote": {
+			"title": "Remove selected emotes from {set}"
+		},
+		"report_emote": {
+			"title": "Report Emote",
+			"choose_reasons": "Choose the reasons",
+			"reasons": {
+				"my_work": "I made this emote but it was uploaded by someone else",
+				"duplicate": "This emote is a duplicate",
+				"sexual": "This emote contains pornographic or overly sexualised imagery",
+				"violance": "This emote displays extreme violence or gore",
+				"its_me": "This emote depicts me and I don't like it",
+				"offensive": "I find this emote offensive",
+				"other": "Other"
+			},
+			"additional_info": "Additional Information",
+			"disclaimer": "Abuse of the report feature may lead to your access being revoked."
+		},
+		"transfer_emote": {
+			"title": "Transfer {emote}",
+			"details": "This will transfer {emote}.",
+			"receipient": "Emote Receipient",
+			"transfer": "Transfer"
+		},
+		"badge": {
+			"title": "Badge"
+		},
+		"subscription": {
+			"gifted_by": "Your subscription was gifted to you by",
+			"cancel_notice": "Ending your subscription now will make you lose access to your subscription benefits immediately. Are you sure you want to end your subscription?",
+			"cancel_confirmation": "Are you sure you want to cancel your subscription? You will lose access to your subscription benefits at the end of your current billing period.",
+			"confirm": "Confirm"
+		},
+		"error": {
+			"title": "Error"
+		},
+		"pickems": {
+			"gift": {
+				"title": "Gift Pick'ems Pass",
+				"gift_to": "Gift Pick'ems Pass to",
+				"recipient": "Select recipient",
+				"back": "Back",
+				"continue": "Continue"
+			}
+		},
+		"gift": {
+			"title": "Gift 1",
+			"gift_to": "Gift 1 {variantUnit(variant)} to",
+			"recipient": "Select recipient"
+		},
+		"paint": {
+			"title": "Paint"
+		},
+		"buttons": {
+			"back": "Back",
+			"continue": "Continue"
+		},
+		"emote-events": {
+			"upload": {
+				"action": "Uploaded"
+			},
+			"process": {
+				"start": "Started a new processing job",
+				"success": "Successfully finished processing",
+				"fail": "Failed processing",
+				"cancel": "Cancelled processing job"
+			},
+			"change_name": {
+				"action": "Renamed"
+			},
+			"merge": {
+				"action": "Merged"
+			},
+			"change_owner": {
+				"action": "Transferred ownership"
+			},
+			"change_tags": {
+				"action": "Set tags to"
+			},
+			"change_flags": {
+				"approved_public": {
+					"action": "Approved for public listing"
+				},
+				"removed_public": {
+					"action": "Removed from public listing"
+				},
+				"approved_personal": {
+					"action": "Approved for personal use"
+				},
+				"rejected_personal": {
+					"action": "Rejected for personal use"
+				},
+				"added_overlaying": {
+					"action": "Added flag overlaying"
+				},
+				"removed_overlaying": {
+					"action": "Removed flag overlaying"
+				},
+				"added_private": {
+					"action": "Added flag private"
+				},
+				"removed_private": {
+					"action": "Removed flag private"
+				}
+			},
+			"delete": {
+				"action": "Deleted"
+			}
+		}
+	},
+	"pages": {
+		"activity": {
+			"title": "Activity",
+			"emote": {
+				"deleted_emote": "Deleted Emote",
+				"deleted_set": "Deleted Set",
+				"by": "by",
+				"created": "Created",
+				"changed_tags": "Changed tags for",
+				"changed_capacity": "Changed capacity for",
+				"added": "Added",
+				"removed": "Removed emote",
+				"renamed": "Renamed emote",
+				"in": "in",
+				"from": "from",
+				"to": "to",
+				"deleted": "Deleted"
+			},
+			"user": {
+				"changed_paint": "Changed active paint from",
+				"changed_badge": "Changed active badge from",
+				"removed": "Removed",
+				"connection": "Connection",
+				"changed_set": "Changed active emote set from",
+				"added": "Added",
+				"no_badge": "No Badge",
+				"no_paint": "No Paint",
+				"deleted": "Deleted"
+			}
+		},
+		"auth": {
+			"title": {
+				"logging": "Logging you in...",
+				"logged": "Logged in",
+				"failed": "Failed to log in"
+			},
+			"state": {
+				"logging": "Logging you in...",
+				"logged": "Logged in",
+				"failed": {
+					"title": "Login Failed",
+					"message": "Make sure to open this window through the extension"
+				}
+			}
+		},
+		"home": {
+			"title": "Home",
+			"features": {
+				"emote_slots": "1000 Emote Slots",
+				"emote_slots_info": "Everyone gets 1000 customisable channel emote slots, all for free. Keep all your emotes in one place.",
+				"emote_slots_button": "Browse Emotes",
+				"emote_sets": "Emote Sets",
+				"emote_sets_info": "Group emotes in customisable sets that can be shared with other users or quickly swapped onto your channel.",
+				"emote_sets_button": "Create an Emote Set",
+				"custom_emotes": "Custom Emote Names",
+				"custom_emotes_info": "Don't like the name given to an emote by its author? That's fine, you can change it for your channel only.",
+				"custom_emotes_button": "Browse Emotes",
+				"real-time": "Real-Time Updates",
+				"real-time_info": "Changing emotes in your channel happens instantly, for all viewers. No F5 required, no more waiting.",
+				"real-time_button": "Download the Extension",
+				"large_community": "Large Community",
+				"large_community_info": "7TV serves 2,000,000+ daily unique users and has a library of over 1,000,000 public emotes.",
+				"large_community_button": "Join our Discord",
+				"next_gen": "Next-gen Formats",
+				"next_gen_info": "We use newer, more optimised image formats like WebP and AVIF, to reduce bandwidth usage.",
+				"next_gen_button": "Download the Extension"
+			}
+		},
+		"help": {
+			"title": "Help"
+		},
+		"directory": {
+			"title": "Directory",
+			"bookmarked": "Bookmarked",
+			"sorting": {
+				"title": "Sorting",
+				"alphabetical": "Alphabetical",
+				"upload_date": "Upload Date"
+			},
+			"filters": {
+				"animated": "Animated",
+				"static": "Static",
+				"overlaying": "Overlaying",
+				"personal_use": "Personal Use",
+				"exact_match": "Exact Match"
+			},
+			"size": {
+				"title": "Size",
+				"any": "Any Size"
+			}
+		},
+		"landing": {
+			"start": "Start your journey with hundreds of emotes and features that enhance your chatting experience. Download the Official 7TV Extension or other 3rd party tools.",
+			"developers": {
+				"header": "Source-Available",
+				"info": "Our entire codebase is available on GitHub with a source-available licence. Anyone can view and contribute."
+			},
+			"download": {
+				"start": "Start your journey with hundreds of emotes and features that enhance your chatting experience. Download the Official 7TV Extension or other 3rd party tools.",
+				"extension": "Web Extension",
+				"recommended": "Recommended",
+				"stable": "Stable Release",
+				"nightly": "Nightly Release",
+				"chatterino": "Chatterino",
+				"mobile": {
+					"apps": "Mobile Apps"
+				},
+				"bots": {
+					"header": "Chat Bots"
+				}
+			},
+			"features": {
+				"header": "Why 7TV?",
+				"info": "Our platform offers a variety of useful features that will enhance your chatting experience."
+			},
+			"footer": {
+				"affiliated": "7TV is not affiliated with Twitch, Kick or Discord",
+				"privacy_policy": "Privacy Policy",
+				"tos": "Terms of Service"
+			},
+			"hero": {
+				"platform": "The Emote Platform",
+				"all": "for All",
+				"download": "Download",
+				"manage": "Manage hundreds of emotes for your Twitch and sKick channels with ease. Enhance your chatting experience.",
+				"more": "Learn more",
+				"xmas": {
+					"header": "X-MAS SUB EVENT",
+					"info": "Gift 1 sub to anyone this christmas and get a special badge!",
+					"gift": "Gift a sub"
+				},
+				"nnys": {
+					"info": "Vote on NNYS 2025 to get an exclusive paint, badge & emote set.",
+					"vote": "Vote in NNYS 2025"
+				},
+				"cs2": {
+					"streamers": "35 STREAMERS",
+					"tournament": "7TV HOSTED TOURNAMENT",
+					"event": "3 DAY EVENT",
+					"header": "Place your Pick'ems. Win Prizes.",
+					"info": "7TV Hoster CS2 Tournament",
+					"date": "Feb. 29th - Mar. 2nd",
+					"pickems": "Place your pick'ems",
+					"pass": "Get the pass!",
+					"badges_paints": "Win Badges & Paints.",
+					"description1": "xQc, OhnePixel, JasonTheWeen and 32 other streamers go head to head",
+					"description2": "in a 3-day Single Elimination 7TV Hosted CS2 tournament."
+				}
+			}
+		},
+		"discover": {
+			"title": "Discover",
+			"uploads": "Uploads",
+			"followed": "Followed accounts"
+		},
+		"store": {
+			"title": "Store",
+			"redeem": {
+				"title": "Redeem",
+				"header": "Redeem a Gift Code",
+				"subtitle": "Redeem a gift code to unlock exclusive cosmetics and benefits.",
+				"state": {
+					"idle": "Idle",
+					"loading": "Loading",
+					"success": "Success"
+				},
+				"code": "code",
+				"shown": "shown",
+				"trial": "You successfully redeemed your trial subscription"
+			},
+			"purchase": {
+				"success": "Your purchase was successfully completed"
+			},
+			"subscription": {
+				"banner_title_subbed": "Thank You For the Support",
+				"banner_title_unsubbed": "Unlock Special Perks",
+				"banner_subtitle_subbed": "Enjoy Your Special Subscriber Perks!",
+				"banner_subtitle_unsubbed": "Subscribe to Enhance Your Chatting Experience.",
+				"badge_progress": {
+					"title": "Badge Progress",
+					"left": "{duration} left"
+				},
+				"benefits": {
+					"title": "Subscription Benefits",
+					"animated_avatar": "Animated Profile Picture",
+					"personal_emotes": "Personal Emotes",
+					"paints": "Nametag Paints",
+					"sub_badge": "Subscriber Badge",
+					"raffle_tickets": "Raffle Tickets"
+				},
+				"raffle": "Global Emote Raffle",
+				"monthly_paints": "Monthly Paints",
+				"your_cosmetics": "Your Cosmetics",
+				"your_paints": "Your Paints",
+				"beomce_a_subscriber": "Become a Subscriber",
+				"your_badges": "Your Badges",
+				"top_gifters": "Top Gifters",
+				"subscribe": "Subscribe",
+				"subscribed": "Subscribed",
+				"cancel": "Cancel Subscription",
+				"reactivate": "Reactivate Subscription",
+				"one_monhth": "1 Month",
+				"one_year": "1 Year"
+			},
+			"paint_bundles": {
+				"coming_soon": "Coming Soon",
+				"banner_title": "Make Yourself Glow",
+				"banner_subtitle": "Nametag Paints Will Let You Express Yourself in Every Hue."
+			},
+			"events": {
+				"no_events": "No upcoming events",
+				"xmas": "X-MAS 2024 EVENT: GIFT 1 SUB TO GET A SPECIAL BADGE",
+				"cs2": {
+					"tournament": "7TV Hosted CS2 Tournament",
+					"cosmetics": "Want to earn cosmetics for predicting the outcome? Click below!",
+					"twitch": "VIEW TWITCH",
+					"bundle": "Purchase Bundle",
+					"already_subscribed": "Already Subscribed",
+					"subscribe": "{price} today, then {recurring}",
+					"billing_cycle": "Billed as one-time purchase",
+					"pickems": {
+						"place": "Place Pick'ems",
+						"predict": "Predict Winners",
+						"purchase_pass": "Purchase Pass"
+					},
+					"pass": {
+						"title": "Pick'ems Pass",
+						"get": "Get Pass",
+						"bundle": "Pass + {variantName(variant)} Subscription Bundle"
+					},
+					"schedule": {
+						"header": "Tournament Schedule",
+						"stage": "Stage",
+						"best_of": "Best of",
+						"start_time": "Start Time"
+					},
+					"streamers": {
+						"header": "Meet the Streamers",
+						"info": "A prominent line-up of Twitch Streamers build a team from their communities who go head-to-head in a CS-Style Single Elimination Tournament.",
+						"watch": "Watch the main event on the",
+						"twitch_channel": "7TV Twitch Channel",
+						"streamer_pov": "or through your favourite streamer's POV."
+					}
+				}
+			}
+		},
+		"admin": {
+			"title": "Admin",
+			"overview": "Overview",
+			"welcome": "Welcome back",
+			"enjoy": "Enjoy modding!",
+			"tickets": {
+				"title": "Tickets",
+				"emotes": {
+					"public_listing": "Public Listing",
+					"personal_use": "Personal Use",
+					"resolved": "Resolved",
+					"not_implemented": "Not Implemented"
+				},
+				"emote_table": {
+					"emote_name": "Emote Name",
+					"uploader": "Uploader",
+					"country": "Country",
+					"tags_flags": "Tags & Flags",
+					"reviewed_by": "Reviewed By"
+				},
+				"reports": "Reports",
+				"reports_options": {
+					"all": "All",
+					"assigned": "Assigned",
+					"closed": "Closed"
+				},
+				"reports_table": {
+					"reported_by": "Reported by",
+					"target": "Target",
+					"description": "Description",
+					"assigned_to": "Assigned to",
+					"status": "Status",
+					"date": "Date",
+					"ticket_id": "Ticket ID",
+					"subject": "Subject",
+					"details": "Details"
+				},
+				"reports_actions": {
+					"close": "Mark as Closed",
+					"assign_self": "Assign Self",
+					"add_comment": "Add comment"
+				}
+			},
+			"codes": {
+				"redeem": "Redeem Codes",
+				"add": "Add Code(s)",
+				"filters": {
+					"header": "Filters:",
+					"remaining_uses": "Remaining Uses"
+				},
+				"search": {
+					"results": "Found {results.totalCount} results ({results.pageCount} pages)"
+				},
+				"attributes": {
+					"name": {
+						"name": "Name",
+						"description": "Description",
+						"tags": "Tags",
+						"code": "Code",
+						"remaining_uses": "Remaining Uses",
+						"active_period": "Active Period",
+						"effect": "Effect",
+						"subscription_effect": "Subscription Effect",
+						"created_by": "Created By",
+						"created_at": "Created At",
+						"actions": "Actions"
+					}
+				},
+				"period": {
+					"unlimited": "Unlimited"
+				},
+				"trial": {
+					"days": "days trial",
+					"no_trial": "No trial",
+					"none": "None"
+				},
+				"system": "System"
+			},
+			"special_events": {
+				"header": "Special Events",
+				"create": "Create Special Event",
+				"add": "Add Special Event",
+				"results": "Found {results.length} results",
+				"attributes": {
+					"name": "Name",
+					"description": "Description",
+					"tags": "Tags",
+					"created_by": "Created By",
+					"created_at": "Created At",
+					"actions": "Actions",
+					"create": "Create",
+					"cancel": "Cancel"
+				},
+				"system": "System",
+				"no_events": "No Special Events"
+			},
+			"users": {
+				"id": {
+					"back": "Back",
+					"last_updated": "Last Updated At",
+					"search_last_update": "Search Last Updated At",
+					"queued": "Queued for update",
+					"stripe": {
+						"customer": "Stripe Customer",
+						"view": "View",
+						"no_customer": "No stripe customer associated",
+						"roles": "Roles"
+					},
+					"actions": {
+						"header": "Actions",
+						"sessions": {
+							"header": "Sessions",
+							"create_session": "Create New Session",
+							"delete_all": "Delete All Sessions",
+							"expiration": "Expiration date in",
+							"token": "Token",
+							"copy_token": "Copy Token",
+							"create": "Create",
+							"close": "Close"
+						},
+						"connections": {
+							"header": "Connections",
+							"kick": "Manually Link Kick",
+							"username": "Kick Username"
+						},
+						"entitlements": {
+							"header": "Entitlements",
+							"create": "Create Entitlements",
+							"assign": "Manually Assign Entitlements",
+							"assign_to": "Assign entitlements to",
+							"remove_all": "Remove All Entitlements",
+							"view": "View Entitlements",
+							"showing": "Showing entitlements assigned to"
+						}
+					},
+					"subscription": {
+						"header": "Subscription",
+						"period": {
+							"header": "Subscription Periods",
+							"key": "Key",
+							"value": "Value",
+							"id": "ID"
+						},
+						"copy": {
+							"ulid": "Copy ULID",
+							"uuid": "Copy UUID"
+						},
+						"provider": {
+							"id": "Provider ID",
+							"view": "View"
+						},
+						"product": {
+							"id": "Product ID",
+							"view": "View",
+							"start": "Start",
+							"end": "End",
+							"is_trial": "Is Trial?",
+							"auto_renew": "Auto Renew?",
+							"gifted": {
+								"header": "Gifted?",
+								"yes": "Yes - By",
+								"no": "No"
+							},
+							"created_by": "Created By",
+							"redeem": "Redeem Code",
+							"invoice": "Invoice",
+							"system": "System",
+							"variant": "Product Variant"
+						}
+					},
+					"not_found": "User not found"
+				},
+				"layout": {
+					"users": "Users"
+				},
+				"page": {
+					"manage": {
+						"header": "Manage",
+						"single_user": "Manage a single user"
+					},
+					"actions": {
+						"header": "Actions",
+						"sub_benefits_job": {
+							"header": "Subscription Benefits Job",
+							"manually": "Manually trigger the subscription job to recalculate entitlements and subscription benefits for all users.",
+							"rerun": "Rerun"
+						}
+					}
+				}
+			}
+		},
+		"emote": {
+			"use_emote": "Use Emote",
+			"add_to": "Add to...",
+			"transfer": "Transfer",
+			"merge": "Merge",
+			"size": "Size",
+			"copy_link": "Copy Link",
+			"info": {
+				"used_by_channels": "Channels using this emote",
+				"channels_tooltip": "Number of channels that currently have this emote active in one of their emote sets.",
+				"trending_this_week": "Trending rank this week",
+				"trending_tooltip": "Position among 7TV's top ~500 emotes by recent growth.",
+				"top_all_time": "Top rank all-time",
+				"top_all_time_tooltip": "Position among 7TV's top ~500 emotes by total net channel adoption.",
+				"not_ranked": "Not currently ranked",
+				"raw_score": "Growth score: {score}",
+				"stats_error": "Couldn't load channel/ranking stats.",
+				"usage_note": "7TV doesn't track how many times an emote is actually sent in chat. The numbers above show how many channels have added this emote and how it ranks in 7TV's trending/top lists."
+			}
+		},
+		"user": {
+			"about": "About",
+			"active_emotes": "Active Emotes",
+			"uploaded": "Uploaded",
+			"uploaded_emotes": "Uploaded Emotes"
+		},
+		"settings": {
+			"account": {
+				"title": "Account",
+				"profile": {
+					"details": "Customise preferences and manage details to suit your individual needs",
+					"display_name": "Display Name",
+					"display_name_description": "Choose a main connection that will be used for your display name and static profile picture",
+					"profile_picture_description": "Choose a profile picture that will be displayed on all platforms",
+					"update_profile_picture": "Update Profile Picture"
+				},
+				"connections": {
+					"details": "Manage and link external accounts to streamline access and enhance interoperability within the platform"
+				},
+				"security": {
+					"title": "Security",
+					"details": "Manage and customise your account security",
+					"2fa": "Two Factor Authentication",
+					"2fa_details": "Enhance the security of your account with Two-Factor Authentication (2FA)",
+					"email_details": "Receive a verification code via email",
+					"authenticator_app": "Authenticator App",
+					"authenticator_app_details": "Install an app to generate your verification code",
+					"sign_out_everywhere": "Sign Out Everywhere",
+					"sign_out_everywhere_details": "Ensure security and log out from all devices with a single click",
+					"delete_account_details": "Permanently remove all personal information and associated data from the platform, terminating your account"
+				}
+			},
+			"appearance": {
+				"title": "Appearance",
+				"details": "Change the look and feel",
+				"theme": {
+					"header": "Theme",
+					"options": {
+						"system": "System",
+						"dark": "Dark",
+						"light": "Light"
+					}
+				},
+				"motion": {
+					"header": "Reduced Motion",
+					"options": {
+						"system": "System",
+						"enabled": "Enabled",
+						"disbaled": "Disabled"
+					}
+				},
+				"right-to-left-layout": {
+					"header": "Website Direction Layout",
+					"options": {
+						"ltr": "Left to Right",
+						"rtl": "Right to Left"
+					}
+				}
+			},
+			"editors": {
+				"details": "Manage and customise your editors or channels your edit for",
+				"editing_for": "Editing For",
+				"add_editor": "Add Editor",
+				"not_allowed": "You are not allowed to manage editors for this user"
+			},
+			"notifications": {
+				"details": "Real-time updates and alerts, keeping users informed about important events, messages, and activities within the website or application"
+			},
+			"blocked": {
+				"title": "Blocked",
+				"details": "Manage your restricted or prohibited content, users, or activities",
+				"add_user": "Add Blocked User"
+			},
+			"billing": {
+				"title": "Billing",
+				"subscription": {
+					"details": "Lorem ipsum dolor sit, amet consectetur adipisicing elit. Magni incidunt numquam itaque, amet ad, pariatur possimus illo atque sunt asperiores molestias autem ex nobis consequuntur culpa. Corporis possimus aspernatur soluta.",
+					"use_credits": "Use Subscription Credits",
+					"use_credits_details": "Your subscription credits will be used first for your next billing",
+					"cancelled": "Subscription Cancelled",
+					"cancelled_details": "Your subscription has been cancelled and your benefits will expire on {date}"
+				},
+				"history": {
+					"title": "Billing History",
+					"details": "See all payment activities associated with your account, such as past billing statements and transactions"
+				},
+				"payment_methods": {
+					"details": "Check and update your preferred payment methods",
+					"add_new": "Add New",
+					"card": {
+						"title": "Card Info",
+						"ends_in": "Ends in {digits}",
+						"expires": "Expires {month}/{year}",
+						"address": "Address",
+						"name": "Name"
+					}
+				},
+				"table": {
+					"status": "Status",
+					"amount": "Amount",
+					"invoice": "Invoice"
+				}
+			},
+			"user_table": {
+				"name": "Name",
+				"last_modified": "Last Modified",
+				"permissions": "Permissions"
+			}
+		},
+		"link": {
+			"linking": "Linking Your Account...",
+			"linking_successful": "Account Successfully Linked",
+			"linking_failed": "Linking Failed"
+		},
+		"extension": {
+			"login": "Logging you in...",
+			"login_successful": "Logged in",
+			"login_failed": "Failed to log in",
+			"window": "Make sure to open this window through the extension"
+		}
+	}
 }

--- a/apps/website/src/locales/en-GB.json
+++ b/apps/website/src/locales/en-GB.json
@@ -908,11 +908,13 @@
 				"used_by_channels": "Channels using this emote",
 				"channels_tooltip": "Number of channels that currently have this emote active in one of their emote sets.",
 				"trending_this_week": "Trending rank this week",
-				"trending_tooltip": "Position among 7TV's top ~500 emotes by recent growth.",
+				"trending_tooltip": "Live position by recent growth under the top 500 emotes.",
 				"top_all_time": "Top rank all-time",
-				"top_all_time_tooltip": "Position among 7TV's top ~500 emotes by total net channel adoption.",
+				"top_all_time_tooltip": "Live position by total net channel adoption under the top 500 emotes.",
 				"not_ranked": "Not currently ranked",
-				"raw_score": "Growth score: {score}",
+				"trending_list_empty": "No emotes found.",
+				"trending_list_error": "Couldn't load the list.",
+				"trending_list_load_more": "Load more",
 				"stats_error": "Couldn't load channel/ranking stats.",
 				"usage_note": "7TV doesn't track how many times an emote is actually sent in chat. The numbers above show how many channels have added this emote and how it ranks in 7TV's trending/top lists."
 			}

--- a/apps/website/src/locales/en.json
+++ b/apps/website/src/locales/en.json
@@ -1,1028 +1,1041 @@
 {
-  "page_titles": {
-    "suffix": "7TV",
-    "admin_suffix": "7TV Admin",
-    "trending_emotes": "Trending Emotes",
-    "top_emotes": "Top Emotes",
-    "global_emotes": "Global Emotes",
-    "new_emotes": "New Emotes",
-    "bookmarked_emotes": "Bookmarked Emotes",
-    "bookmarked_emote_sets": "Bookmarked Emote Sets",
-    "bookmarked_users": "Bookmarked Users",
-    "account_settings": "Account Settings",
-    "editor_settings": "Editor Settings",
-    "notification_settings": "Notification Settings",
-    "blocked_settings": "Blocked Settings",
-    "billing_settings": "Billing Settings",
-    "admin_emote_public_listing": "Emote Public Listing Requests",
-    "admin_emote_personal_use": "Emote Personal Use Requests",
-    "admin_emote_resolved": "Resolved Emote Tickets"
-  },
-  "page_errors": {
-    "not_found": "The page you were looking for could not be found.",
-    "forbidden": "You do not have permission to view this page.",
-    "unauthorized": "You are unauthorized to view this page.",
-    "unexpected": "You can try refreshing the page. If the problem persists, please contact us.",
-    "generic": "An error occurred.",
-    "emote_set_load": "Failed to load emote set",
-    "emote_set_not_found": "Emote set not found",
-    "user": "Failed to load user"
-  },
-  "words": {
-    "from": "from",
-    "to": "to",
-    "with": "with",
-    "by": "by"
-  },
-  "common": {
-    "sign_in": "Sign In",
-    "sign_out": "Sign Out",
-    "go_back": "Go Back",
-    "super_admin": "Super Admin",
-    "skip_to_content": "Skip to content",
-    "emotes": "{count, plural, one {Emote} other {Emotes}}",
-    "emote_sets": "{count, plural, one {Emote Set} other {Emote Sets}}",
-    "users": "{count, plural, one {User} other {Users}}",
-    "channels": "{count, plural, one {Channel} other {Channels}}",
-    "followers": "{count, plural, one {Follower} other {Followers}}",
-    "items": "{count, plural, one {Item} other {Items}}",
-    "subscriptions": "{count, plural, one {Subscription} other {Subscriptions}}",
-    "payment_methods": "{count, plural, one {Payment Method} other {Payment Methods}}",
-    "date": "Date",
-    "help": "Help",
-    "for": "for",
-    "error": "Error",
-    "loading": "Loading...",
-    "paint_bundles": "Paint Bundles",
-    "notifications": "Notifications",
-    "connections": "Connections",
-    "direct_messages": "Direct Messages",
-    "mod_comments": "Mod Comments",
-    "profile_picture": "Profile Picture",
-    "suggested_emotes": "Suggested Emotes",
-    "personal_emotes": "Personal Emotes",
-    "no_more_emotes": "No more emotes",
-    "no_emotes": "No emotes",
-    "your_subscription": "Your Subscription",
-    "theme": "Theme",
-    "language": "Language",
-    "developer_portal": "Developer Portal",
-    "faq": "Frequently Asked Questions",
-    "faq_short": "FAQ",
-    "privacy": "Privacy Policy",
-    "tos": "Terms of Service",
-    "trending": "Trending",
-    "top": "Top",
-    "global": "Global",
-    "new": "New",
-    "Weekly": "Weekly",
-    "Monthly": "Monthly",
-    "Today": "Today",
-    "news": "News",
-    "Default_set": "Default Set",
-    "following": "Following",
-    "activity": "Activity",
-    "analytics": "Analytics",
-    "statistics": "Statistics",
-    "contact": "Contact",
-    "cosmetics": "Cosmetics",
-    "editors": "Editors",
-    "active": "Active",
-    "profile": "Profile",
-    "pinned": "Pinned",
-    "settings": "Settings",
-    "delete_account": "Delete Account"
-  },
-  "labels": {
-    "enter_text": "Enter text",
-    "redeem": "Enter code",
-    "search": "Search",
-    "refetch": "Refetch",
-    "manage_connections": "Manage Connections",
-    "manage_editors": "Manage Editors",
-    "none": "None",
-    "search_user": "Search User",
-    "search_country": "Search Country",
-    "search_emote_set": "Search Emote Set",
-    "search_users": "{count, plural, one {Search a user} other {Search users}}",
-    "tags": "Tags",
-    "close": "Close",
-    "contribute": "Contribute",
-    "enter_tags": "Enter tags",
-    "tag_limit_reached": "Tag limit of {limit} reached",
-    "filters": "Filters",
-    "no_filters": "No Filters",
-    "emote_name": "Emote Name",
-    "copy_link": "Copy Link",
-    "create_emote_set": "Create New Set",
-    "emote_set_name": "Emote Set Name",
-    "emote_attribution": "Emote Attribution",
-    "select": "Select",
-    "selection_mode": "Selection Mode",
-    "edit": "Edit",
-    "capacity": "Capacity",
-    "enable": "Enable",
-    "disable": "Disable",
-    "disabled": "Disabled",
-    "more": "More",
-    "actions": "Actions",
-    "download": "Download",
-    "report": "Report",
-    "delete": "Delete",
-    "time_select": {
-      "week": "This Week",
-      "month": "This Month",
-      "year": "This Year"
-    },
-    "gift": "Gift",
-    "follow": "Follow",
-    "connect": "Connect",
-    "disconnect": "Disconnect",
-    "email": "Email",
-    "password": "Password",
-    "all": "All",
-    "other": "Other",
-    "cancel": "Cancel",
-    "confirm": "Confirm",
-    "proceed": "Proceed",
-    "save": "Save",
-    "remove": "Remove",
-    "accept": "Accept",
-    "deny": "Deny",
-    "enter": "Enter"
-  },
-  "themes": {
-    "system": "System",
-    "dark": "Dark",
-    "light": "Light"
-  },
-  "flags": {
-    "global": "Global",
-    "trending": "Trending",
-    "overlaying": "Overlaying",
-    "default": "Default",
-    "personal": "Personal",
-    "listed": "Listed",
-    "unlisted": "Unlisted",
-    "personal_use": "Personal Use",
-    "deleted": "Deleted",
-    "private": "Private",
-    "personal_use_approved": "Approved Personal Use",
-    "personal_use_denied": "Denied Personal Use",
-    "personal_use_pending": "Personal Use Pending Review",
-    "renamed": "Renamed",
-    "nsfw": "NSFW",
-    "editor_flags": {
-      "pending": "Pending",
-      "accepted": "Accepted",
-      "rejected": "Rejected",
-      "you_accepted": "You Accepted",
-      "you_rejected": "You Rejected"
-    }
-  },
-  "notifications": {
-    "system": "System",
-    "approved_for_public": "Your emote {emote} has been approved for public listing."
-  },
-  "sub_info": {
-    "plan": "Plan",
-    "free": "Free",
-    "gifted_by": "Gifted by",
-    "ends": "Sub Ends",
-    "total": "Total",
-    "credits": "Sub Credits"
-  },
-  "file_limits": {
-    "max_size": "{size} max file size",
-    "max_resolution": "{width}x{height} max resolution",
-    "max_frames": "{count} max frames",
-    "resolution_error": "Resolution must not exceed {width}x{height}",
-    "duration_error": "Duration must be {duration} seconds or less"
-  },
-  "dialogs": {
-    "sign_in": {
-      "title": "Sign in to 7TV",
-      "subtitle": "Sign in or create an account to continue",
-      "continue_with": "Continue with {platform}",
-      "trouble": "Trouble signing in?",
-      "legal_yapping": "By signing in, you agree to our",
-      "and": "and",
-      "linking_new": "Already have a 7TV account and plan on linking a new connection? Sign in with your existing connection and link the new one in the",
-      "settings": "settings"
-    },
-    "search": {
-      "emotes": "Emotes",
-      "users": "Users"
-    },
-    "upload": {
-      "title": "Upload Emote",
-      "untitled": "Untitled",
-      "chat": "Send a message",
-      "drag_drop": "Drag & Drop to upload, or",
-      "browse_files": "Browse Files",
-      "accept_rules": "I accept the rules and guidelines",
-      "discard": "Discard",
-      "upload_guidelines": "Emote Upload Guidelines",
-      "upload": "Upload"
-    },
-    "emote_set": {
-      "title": "Active Emote Set",
-      "create": "Create Emote Set",
-      "name": "Emote Set Name",
-      "label": "Name",
-      "confirm": "Create",
-      "copy_set": "Copy Set",
-      "special": "Special",
-      "favourite_sets": {
-        "title": "Favorite Emote Sets",
-        "add": "Add & Rename to all",
-        "remove": "Remove from all"
-      },
-      "mass_select_feature":{
-        "add": "Add to Emote-Set",
-        "remove": "Remove from Emote-Set",
-        "amount_selected_label": "/20 Selected"
-      },
-      "default_emote_set": {
-        "remove": "Remove Emote from {set}",
-        "add": "Add Emote to {set}",
-        "conflicting_name": "Conflicting Name"
-      }
-    },
-    "manage_aliases": {
-      "title": "Manage Emote Aliases",
-      "add_placeholder": "Add new alias.."
-    },
-    "rename_emote": {
-      "title": "Rename Emote in {set}",
-      "input_placeholder": "New emote name",
-      "confirmation_message": "Are you sure you want to rename this emote in {set}?",
-      "confirm": "Rename"
-    },
-    "remove_emote_from_set": {
-      "title": "Remove Emote from {set}",
-      "warning_message": "Are you sure you want to remove {emote} from {set}?",
-      "confirm": "Remove"
-    },
-    "add_emote": {
-      "title": "Add {emote} to",
-      "change_name": "Change emote name",
-      "confirm": "Confirm",
-      "confirm_changes": "{count, plural, one {Confirm 1 change} other {Confirm {count} changes}}"
-    },
-    "emote_ticket": {
-      "emote_queue": "Emote queue",
-      "activity": "Activity",
-      "comments": "Comments"
-    },
-    "emote_context_menu": {
-      "add_remove_emote": "Add/Remove Emote",
-      "edit_emote_alias": "Edit Emote Alias",
-      "remove_emote": "Remove Emote From Set",
-      "open_in_new_tab": "Open in New Tab",
-      "copy_emote_link": "Copy Emote Link"
-    },
-    "cart": {
-      "title": "Your Cart",
-      "duration": "Duration",
-      "price": "Price",
-      "preview": "Preview",
-      "purchase_as_gift": "Purchase as a gift",
-      "total": "Total"
-    },
-    "editor": {
-      "permissions": "Set Editor Permissions",
-      "super_admin": "Super Admin",
-      "emote_sets": "Emote Sets",
-      "admin": "Admin",
-      "emotes": "Emotes",
-      "user": "User",
-      "manage_personal_emotes": "Manage Personal Emote Set",
-      "confirm": "Confirm",
-      "no_editors": "No editors to show",
-      "permissions_details": {
-        "manage": "Manage",
-        "create": "Create",
-        "transfer": "Transfer",
-        "manage_profile": "Manage Profile",
-        "manage_emotes": "Manage Emotes",
-        "manage_billing": "Manage Billing",
-        "manage_editors": "Manage Editors",
-        "view_billing": "View Billing Information"
-      }
-    },
-    "emote_info": {
-      "processing": "This emote is still processing",
-      "refresh": "Refresh",
-      "download": "Download"
-    },
-    "copy_emotes": {
-      "title": "Copy selected emotes to"
-    },
-    "default_set": {
-      "title": "Default Emote Set"
-    },
-    "delete_account": {
-      "warning": "Warning",
-      "warning_message": "This action will delete your account permanently. You cannot undo this action.",
-      "choose_reasons": "Choose the reasons for account deletion",
-      "reasons": {
-        "no_longer_use": "I no longer use 7TV",
-        "privacy_concerns": "Privacy concerns",
-        "not_useful": "Not useful",
-        "other": "Other"
-      },
-      "confirm_username": "Enter your username to confirm"
-    },
-    "delete_emote_or_set": {
-      "title": "Delete {name}",
-      "warning_message_emote": "This will delete your emote permanently. You cannot undo this action.",
-      "warning_message_set": "This will delete your emote set permanently. You cannot undo this action.",
-      "reason": "Reason",
-      "reason_for_deletion": "Reason for deletion"
-    },
-    "edit_emote": {
-      "title": "Edit {emote}"
-    },
-    "edit_emote_set": {
-      "title": "Edit Emote Set",
-      "show_on_profile": "Show on Profile",
-      "publicly_listed": "Publicly Listed"
-    },
-    "remove_emote": {
-      "title": "Remove selected emotes from {set}"
-    },
-    "report_emote": {
-      "title": "Report Emote",
-      "choose_reasons": "Choose the reasons",
-      "reasons": {
-        "my_work": "I made this emote but it was uploaded by someone else",
-        "duplicate": "This emote is a duplicate",
-        "sexual": "This emote contains pornographic or overly sexualized imagery",
-        "violance": "This emote displays extreme violence or gore",
-        "its_me": "This emote depicts me and I don't like it",
-        "offensive": "I find this emote offensive",
-        "other": "Other"
-      },
-      "additional_info": "Additional Information",
-      "disclaimer": "Abuse of the report feature may lead to your access being revoked."
-    },
-    "transfer_emote": {
-      "title": "Transfer {emote}",
-      "details": "This will transfer {emote}.",
-      "receipient": "Emote Receipient",
-      "transfer": "Transfer"
-    },
-    "badge": {
-      "title": "Badge"
-    },
-    "subscription": {
-      "gifted_by": "Your subscription was gifted to you by",
-      "cancel_notice": "Ending your subscription now will make you lose access to your subscription benefits immediately. Are you sure you want to end your subscription?",
-      "cancel_confirmation": "Are you sure you want to cancel your subscription? You will lose access to your subscription benefits at the end of your current billing period.",
-      "confirm": "Confirm"
-    },
-    "error": {
-      "title": "Error"
-    },
-    "pickems": {
-      "gift": {
-        "title": "Gift Pick'ems Pass",
-        "gift_to": "Gift Pick'ems Pass to",
-        "recipient": "Select recipient",
-        "back": "Back",
-        "continue": "Continue"
-      }
-    },
-    "gift": {
-      "title": "Gift 1",
-      "gift_to": "Gift 1 {variant} to",
-      "recipient": "Select recipient"
-    },
-    "paint": {
-      "title": "Paint"
-    },
-    "buttons": {
-      "back": "Back",
-      "continue": "Continue"
-    },
-    "emote-events": {
-      "upload": {
-        "action": "Uploaded"
-      },
-      "process": {
-        "start": "Started a new processing job",
-        "success": "Successfully finished processing",
-        "fail": "Failed processing",
-        "cancel": "Cancelled processing job"
-      },
-      "change_name": {
-        "action": "Renamed"
-      },
-      "merge": {
-        "action": "Merged"
-      },
-      "change_owner": {
-        "action": "Transferred ownership"
-      },
-      "change_tags": {
-        "action": "Set tags to"
-      },
-      "change_flags": {
-        "approved_public": {
-          "action": "Approved for public listing"
-        },
-        "removed_public": {
-          "action": "Removed from public listing"
-        },
-        "approved_personal": {
-          "action": "Approved for personal use"
-        },
-        "rejected_personal": {
-          "action": "Rejected for personal use"
-        },
-        "added_overlaying": {
-          "action": "Added flag overlaying"
-        },
-        "removed_overlaying": {
-          "action": "Removed flag overlaying"
-        },
-        "added_private": {
-          "action": "Added flag private"
-        },
-        "removed_private": {
-          "action": "Removed flag private"
-        }
-      },
-      "delete": {
-        "action": "Deleted"
-      }
-    }
-  },
-  "pages": {
-    "activity": {
-      "title": "Activity",
-      "emote": {
-        "deleted_emote": "Deleted Emote",
-        "deleted_set": "Deleted Set",
-        "by": "by",
-        "created": "Created",
-        "changed_tags": "Changed tags for",
-        "changed_capacity": "Changed capacity for",
-        "added": "Added",
-        "removed": "Removed emote",
-        "renamed": "Renamed emote",
-        "in": "in",
-        "from": "from",
-        "to": "to",
-        "deleted": "Deleted"
-      },
-      "user": {
-        "changed_paint": "Changed active paint from",
-        "changed_badge": "Changed active badge from",
-        "removed": "Removed",
-        "connection": "Connection",
-        "changed_set": "Changed active emote set from",
-        "added": "Added",
-        "no_badge": "No Badge",
-        "no_paint": "No Paint",
-        "deleted": "Deleted"
-      }
-    },
-    "auth": {
-      "title": {
-        "logging": "Logging you in...",
-        "logged": "Logged in",
-        "failed": "Failed to log in"
-      },
-      "state": {
-       "logging": "Logging you in...",
-        "logged": "Logged in",
-        "failed": {
-          "title": "Login Failed",
-          "message": "Make sure to open this window through the extension"
-        }
-      }
-    },
-    "home": {
-      "title": "Home",
-      "features": {
-        "emote_slots": "1000 Emote Slots",
-        "emote_slots_info": "Everyone gets 1000 customizable channel emote slots, all for free. Keep all your emotes in one place.",
-        "emote_slots_button": "Browse Emotes",
-        "emote_sets": "Emote Sets",
-        "emote_sets_info": "Group emotes in customizable sets that can be shared with other users or quickly swapped onto your channel.",
-        "emote_sets_button": "Create an Emote Set",
-        "custom_emotes": "Custom Emote Names",
-        "custom_emotes_info": "Don't like the name given to an emote by its author? That's fine, you can change it for your channel only.",
-        "custom_emotes_button": "Browse Emotes",
-        "real-time": "Real-Time Updates",
-        "real-time_info": "Changing emotes in your channel happens instantly, for all viewers. No F5 required, no more waiting.",
-        "real-time_button": "Download the Extension",
-        "large_community": "Large Community",
-        "large_community_info": "7TV serves 2,000,000+ daily unique users and has a library of over 1,000,000 public emotes.",
-        "large_community_button": "Join our Discord",
-        "next_gen": "Next-gen Formats",
-        "next_gen_info": "We use newer, more optimized image formats like WebP and AVIF, to reduce bandwidth usage.",
-        "next_gen_button": "Download the Extension"
-      }
-    },
-    "help": {
-      "title": "Help"
-    },
-    "directory": {
-      "title": "Directory",
-      "bookmarked": "Bookmarked",
-      "sorting": {
-        "title": "Sorting",
-        "alphabetical": "Alphabetical",
-        "upload_date": "Upload Date"
-      },
-      "filters": {
-        "animated": "Animated",
-        "static": "Static",
-        "overlaying": "Overlaying",
-        "personal_use": "Personal Use",
-        "exact_match": "Exact Match"
-      },
-      "size": {
-        "title": "Size",
-        "any": "Any Size"
-      }
-    },
-    "landing": {
-      "start": "Start your journey with hundreds of emotes and features that enhance your chatting experience. Download the Official 7TV Extension or other 3rd party tools.",
-      "developers": {
-        "header": "Source-Available",
-        "info": "Our entire codebase is available on GitHub with a source-available license. Anyone can view and contribute."
-      },
-      "download": {
-        "start": "Start your journey with hundreds of emotes and features that enhance your chatting experience. Download the Official 7TV Extension or other 3rd party tools.",
-        "extension": "Web Extension",
-        "recommended": "Recommended",
-        "stable": "Stable Release",
-        "nightly": "Nightly Release",
-        "chatterino": "Chatterino",
-        "mobile": {
-          "apps": "Mobile Apps"
-        },
-        "bots": {
-          "header": "Chat Bots"
-        }
-      },
-      "features": {
-        "header": "Why 7TV?",
-        "info": "Our platform offers a variety of useful features that will enhance your chatting experience."
-      },
-      "footer": {
-        "affiliated": "7TV is not affiliated with Twitch, Kick or Discord",
-        "privacy_policy": "Privacy Policy",
-        "tos": "Terms of Service"
-      },
-      "hero": {
-        "platform": "The Emote Platform",
-        "all": "for All",
-        "download": "Download",
-        "manage": "Manage hundreds of emotes for your Twitch and Kick channels with ease. Enhance your chatting experience.",
-        "more": "Learn more",
-        "xmas": {
-          "header": "X-MAS sSUB EVENT",
-          "info": "Gift 1 sub to anyone this christmas and get a special badge!",
-          "gift": "Gift a sub"
-        },
-        "nnys": {
-          "info": "Vote on NNYS 2025 to get an exclusive paint, badge & emote set.",
-          "vote": "Vote in NNYS 2025"
-        },
-        "cs2": {
-          "streamers": "35 STREAMERS",
-          "tournament": "7TV HOSTED TOURNAMENT",
-          "event": "3 DAY EVENT",
-          "header": "Place your Pick'ems. Win Prizes.",
-          "info": "7TV Hoster CS2 Tournament",
-          "date": "Feb. 29th - Mar. 2nd",
-          "pickems": "Place your pick'ems",
-          "pass": "Get the pass!",
-          "badges_paints": "Win Badges & Paints.",
-          "description1": "xQc, OhnePixel, JasonTheWeen and 32 other streamers go head to head",
-          "description2": "in a 3-day Single Elimination 7TV Hosted CS2 tournament."
-        }
-      }
-    },
-    "discover": {
-      "title": "Discover",
-      "uploads": "Uploads",
-      "followed": "Followed accounts"
-    },
-    "store": {
-      "title": "Store",
-      "redeem": {
-        "title": "Redeem",
-        "header": "Redeem a Gift Code",
-        "subtitle": "Redeem a gift code to unlock exclusive cosmetics and benefits.",
-        "state": {
-          "idle": "Idle",
-          "loading": "Loading",
-          "success": "Success"
-        },
-        "code": "code",
-        "shown": "shown",
-        "trial": "You successfully redeemed your trial subscription"
-      },
-      "purchase": {
-        "success": "Your purchase was successfully completed"
-      },
-      "subscription": {
-        "banner_title_subbed": "Thank You For the Support",
-        "banner_title_unsubbed": "Unlock Special Perks",
-        "banner_subtitle_subbed": "Enjoy Your Special Subscriber Perks!",
-        "banner_subtitle_unsubbed": "Subscribe to Enhance Your Chatting Experience.",
-        "badge_progress": {
-          "title": "Badge Progress",
-          "left": "{duration} left"
-        },
-        "benefits": {
-          "title": "Subscription Benefits",
-          "animated_avatar": "Animated Profile Picture",
-          "personal_emotes": "Personal Emotes",
-          "paints": "Nametag Paints",
-          "sub_badge": "Subscriber Badge",
-          "raffle_tickets": "Raffle Tickets"
-        },
-        "raffle": "Global Emote Raffle",
-        "monthly_paints": "Monthly Paints",
-        "your_cosmetics": "Your Cosmetics",
-        "your_paints": "Your Paints",
-        "beomce_a_subscriber": "Become a Subscriber",
-        "your_badges": "Your Badges",
-        "top_gifters": "Top Gifters",
-        "subscribe": "Subscribe",
-        "subscribed": "Subscribed",
-        "cancel": "Cancel Subscription",
-        "reactivate": "Reactivate Subscription",
-        "one_monhth": "1 Month",
-        "one_year": "1 Year"
-      },
-      "paint_bundles": {
-        "coming_soon": "Coming Soon",
-        "banner_title": "Make Yourself Glow",
-        "banner_subtitle": "Nametag Paints Will Let You Express Yourself in Every Hue."
-      },
-      "events": {
-        "no_events": "No upcoming events",
-        "xmas": "X-MAS 2024 EVENT: GIFT 1 SUB TO GET A SPECIAL BADGE",
-        "cs2": {
-          "tournament": "7TV Hosted CS2 Tournament",
-          "cosmetics": "Want to earn cosmetics for predicting the outcome? Click below!",
-          "twitch": "VIEW TWITCH",
-          "bundle": "Purchase Bundle",
-          "already_subscribed": "Already Subscribed",
-          "subscribe": "{price} today, then {recurring}",
-          "billing_cycle": "Billed as one-time purchase",
-          "pickems": {
-            "place": "Place Pick'ems",
-            "predict": "Predict Winners",
-            "purchase_pass": "Purchase Pass"
-          },
-          "pass": {
-            "title": "Pick'ems Pass",
-            "get": "Get Pass",
-            "bundle": "Pass + {variantName(variant)} Subscription Bundle"
-          },
-          "schedule": {
-            "header": "Tournament Schedule",
-            "stage": "Stage",
-            "best_of": "Best of",
-            "start_time": "Start Time"
-          },
-          "streamers": {
-            "header": "Meet the Streamers",
-            "info": "A prominent line-up of Twitch Streamers build a team from their communities who go head-to-head in a CS-Style Single Elimination Tournament.",
-            "watch": "Watch the main event on the",
-            "twitch_channel": "7TV Twitch Channel",
-            "streamer_pov": "or through your favourite streamer's POV."
-          }
-        }
-      }
-    },
-    "admin": {
-      "title": "Admin",
-      "overview": "Overview",
-      "welcome": "Welcome back",
-      "enjoy": "Enjoy modding!",
-      "tickets": {
-        "title": "Tickets",
-        "emotes": {
-          "public_listing": "Public Listing",
-          "personal_use": "Personal Use",
-          "resolved": "Resolved",
-          "not_implemented": "Not Implemented"
-        },
-        "emote_table": {
-          "emote_name": "Emote Name",
-          "uploader": "Uploader",
-          "country": "Country",
-          "tags_flags": "Tags & Flags",
-          "reviewed_by": "Reviewed By"
-        },
-        "reports": "Reports",
-        "reports_options": {
-          "all": "All",
-          "assigned": "Assigned",
-          "closed": "Closed"
-        },
-        "reports_table": {
-          "reported_by": "Reported by",
-          "target": "Target",
-          "description": "Description",
-          "assigned_to": "Assigned to",
-          "status": "Status",
-          "date": "Date",
-          "ticket_id": "Ticket ID",
-          "subject": "Subject",
-          "details": "Details"
-        },
-        "reports_actions": {
-          "close": "Mark as Closed",
-          "assign_self": "Assign Self",
-          "add_comment": "Add comment"
-        }
-      },
-      "codes": {
-        "redeem": "Redeem Codes",
-        "add": "Add Code(s)",
-        "filters": {
-          "header": "Filters:",
-          "remaining_uses": "Remaining Uses"
-        },
-        "search": {
-          "results": "Found {results.totalCount} results ({results.pageCount} pages)"
-        },
-        "attributes": {
-          "name": {
-            "name": "Name",
-            "description": "Description",
-            "tags": "Tags",
-            "code": "Code",
-            "remaining_uses": "Remaining Uses",
-            "active_period": "Active Period",
-            "effect": "Effect",
-            "subscription_effect": "Subscription Effect",
-            "created_by": "Created By",
-            "created_at": "Created At",
-            "actions": "Actions"
-          }
-        },
-        "period": {
-          "unlimited": "Unlimited"
-        },
-        "trial": {
-          "days": "days trial",
-          "no_trial": "No trial",
-          "none": "None"
-        },
-        "system": "System"
-      },
-      "special_events": {
-        "header": "Special Events",
-        "create": "Create Special Event",
-        "add": "Add Special Event",
-        "results": "Found {results.length} results",
-        "attributes": {
-          "name": "Name",
-          "description": "Description",
-          "tags": "Tags",
-          "created_by": "Created By",
-          "created_at": "Created At",
-          "actions": "Actions",
-          "create": "Create",
-          "cancel": "Cancel"
-        },
-        "system": "System",
-        "no_events": "No Special Events"
-      },
-      "users": {
-        "id": {
-          "back": "Back",
-          "last_updated": "Last Updated At",
-          "search_last_update": "Search Last Updated At",
-          "queued": "Queued for update",
-          "stripe": {
-            "customer": "Stripe Customer",
-            "view": "View",
-            "no_customer": "No stripe customer associated",
-            "roles": "Roles"
-          },
-          "actions": {
-            "header": "Actions",
-            "sessions": {
-              "header": "Sessions",
-              "create_session": "Create New Session",
-              "delete_all": "Delete All Sessions",
-              "expiration": "Expiration date in",
-              "token": "Token",
-              "copy_token": "Copy Token",
-              "create": "Create",
-              "close": "Close"
-            },
-            "connections": {
-              "header": "Connections",
-              "kick": "Manually Link Kick",
-              "username": "Kick Username"
-            },
-            "entitlements": {
-              "header": "Entitlements",
-              "create": "Create Entitlements",
-              "assign": "Manually Assign Entitlements",
-              "assign_to": "Assign entitlements to",
-              "remove_all": "Remove All Entitlements",
-              "view": "View Entitlements",
-              "showing": "Showing entitlements assigned to"
-            }
-          },
-          "subscription": {
-            "header": "Subscription",
-            "period": {
-              "header": "Subscription Periods",
-              "key": "Key",
-              "value": "Value",
-              "id": "ID"
-            },
-            "copy": {
-              "ulid": "Copy ULID",
-              "uuid": "Copy UUID"
-            },
-            "provider": {
-              "id": "Provider ID",
-              "view": "View"
-            },
-            "product": {
-              "id": "Product ID",
-              "view": "View",
-              "start": "Start",
-              "end": "End",
-              "is_trial": "Is Trial?",
-              "auto_renew": "Auto Renew?",
-              "gifted": {
-                "header": "Gifted?",
-                "yes": "Yes - By",
-                "no": "No"
-              },
-              "created_by": "Created By",
-              "redeem": "Redeem Code",
-              "invoice": "Invoice",
-              "system": "System",
-              "variant": "Product Variant"
-            }
-          },
-          "not_found": "User not found"
-        },
-        "layout": {
-          "users": "Users"
-        },
-        "page": {
-          "manage": {
-            "header": "Manage",
-            "single_user": "Manage a single user"
-          },
-          "actions": {
-            "header": "Actions",
-            "sub_benefits_job": {
-              "header": "Subscription Benefits Job",
-              "manually": "Manually trigger the subscription job to recalculate entitlements and subscription benefits for all users.",
-              "rerun": "Rerun"
-            }
-          }
-        }
-      }
-    },
-    "emote": {
-      "use_emote": "Use Emote",
-      "add_to": "Add to...",
-      "transfer": "Transfer",
-      "merge": "Merge",
-      "size": "Size",
-      "copy_link": "Copy Link"
-    },
-    "user": {
-      "about": "About",
-      "active_emotes": "Active Emotes",
-      "uploaded": "Uploaded",
-      "uploaded_emotes": "Uploaded Emotes"
-    },
-    "settings": {
-      "account": {
-        "title": "Account",
-        "profile": {
-          "details": "Customize preferences and manage details to suit your individual needs",
-          "display_name": "Display Name",
-          "display_name_description": "Choose a main connection that will be used for your display name and static profile picture",
-          "profile_picture_description": "Choose a profile picture that will be displayed on all platforms",
-          "update_profile_picture": "Update Profile Picture"
-        },
-        "connections": {
-          "details": "Manage and link external accounts to streamline access and enhance interoperability within the platform"
-        },
-        "security": {
-          "title": "Security",
-          "details": "Manage and customize your account security",
-          "2fa": "Two Factor Authentication",
-          "2fa_details": "Enhance the security of your account with Two-Factor Authentication (2FA)",
-          "email_details": "Receive a verification code via email",
-          "authenticator_app": "Authenticator App",
-          "authenticator_app_details": "Install an app to generate your verification code",
-          "sign_out_everywhere": "Sign Out Everywhere",
-          "sign_out_everywhere_details": "Ensure security and log out from all devices with a single click",
-          "delete_account_details": "Permanently remove all personal information and associated data from the platform, terminating your account"
-        }
-      },
-      "appearance": {
-        "title": "Appearance",
-        "details": "Change the look and feel",
-        "theme": {
-          "header": "Theme",
-          "options": {
-            "system": "System",
-            "dark": "Dark",
-            "light": "Light"
-          }
-        },
-        "motion": {
-          "header": "Reduced Motion",
-          "options": {
-            "system": "System",
-            "enabled": "Enabled",
-            "disbaled": "Disabled"
-          }
-        },
-        "right-to-left-layout": {
-          "header": "Website Direction Layout",
-          "options": {
-            "ltr": "Left to Right",
-            "rtl": "Right to Left"
-          }
-        }
-      },
-      "editors": {
-        "details": "Manage and customize your editors or channels you edit for",
-        "editing_for": "Editing For",
-        "add_editor": "Add Editor",
-        "not_allowed": "You are not allowed to manage editors for this user"
-      },
-      "notifications": {
-        "details": "Real-time updates and alerts, keeping users informed about important events, messages, and activities within the website or application"
-      },
-      "blocked": {
-        "title": "Blocked",
-        "details": "Manage your restricted or prohibited content, users, or activities",
-        "add_user": "Add Blocked User"
-      },
-      "billing": {
-        "title": "Billing",
-        "subscription": {
-          "details": "Lorem ipsum dolor sit, amet consectetur adipisicing elit. Magni incidunt numquam itaque, amet ad, pariatur possimus illo atque sunt asperiores molestias autem ex nobis consequuntur culpa. Corporis possimus aspernatur soluta.",
-          "use_credits": "Use Subscription Credits",
-          "use_credits_details": "Your subscription credits will be used first for your next billing",
-          "cancelled": "Subscription Cancelled",
-          "cancelled_details": "Your subscription has been cancelled and your benefits will expire on {date}"
-        },
-        "history": {
-          "title": "Billing History",
-          "details": "See all payment activities associated with your account, such as past billing statements and transactions"
-        },
-        "payment_methods": {
-          "details": "Check and update your preferred payment methods",
-          "add_new": "Add New",
-          "card": {
-            "title": "Card Info",
-            "ends_in": "Ends in {digits}",
-            "expires": "Expires {month}/{year}",
-            "address": "Address",
-            "name": "Name"
-          }
-        },
-        "table": {
-          "status": "Status",
-          "amount": "Amount",
-          "invoice": "Invoice"
-        }
-      },
-      "user_table": {
-        "name": "Name",
-        "last_modified": "Last Modified",
-        "permissions": "Permissions"
-      }
-    },
-    "link": {
-      "linking": "Linking Your Account...",
-      "linking_successful": "Account Successfully Linked",
-      "linking_failed": "Linking Failed"
-    },
-    "extension": {
-      "login": "Logging you in...",
-      "login_successful": "Logged in",
-      "login_failed": "Failed to log in",
-      "window": "Make sure to open this window through the extension"
-    }
-  }
+	"page_titles": {
+		"suffix": "7TV",
+		"admin_suffix": "7TV Admin",
+		"trending_emotes": "Trending Emotes",
+		"top_emotes": "Top Emotes",
+		"global_emotes": "Global Emotes",
+		"new_emotes": "New Emotes",
+		"bookmarked_emotes": "Bookmarked Emotes",
+		"bookmarked_emote_sets": "Bookmarked Emote Sets",
+		"bookmarked_users": "Bookmarked Users",
+		"account_settings": "Account Settings",
+		"editor_settings": "Editor Settings",
+		"notification_settings": "Notification Settings",
+		"blocked_settings": "Blocked Settings",
+		"billing_settings": "Billing Settings",
+		"admin_emote_public_listing": "Emote Public Listing Requests",
+		"admin_emote_personal_use": "Emote Personal Use Requests",
+		"admin_emote_resolved": "Resolved Emote Tickets"
+	},
+	"page_errors": {
+		"not_found": "The page you were looking for could not be found.",
+		"forbidden": "You do not have permission to view this page.",
+		"unauthorized": "You are unauthorized to view this page.",
+		"unexpected": "You can try refreshing the page. If the problem persists, please contact us.",
+		"generic": "An error occurred.",
+		"emote_set_load": "Failed to load emote set",
+		"emote_set_not_found": "Emote set not found",
+		"user": "Failed to load user"
+	},
+	"words": {
+		"from": "from",
+		"to": "to",
+		"with": "with",
+		"by": "by"
+	},
+	"common": {
+		"sign_in": "Sign In",
+		"sign_out": "Sign Out",
+		"go_back": "Go Back",
+		"super_admin": "Super Admin",
+		"skip_to_content": "Skip to content",
+		"emotes": "{count, plural, one {Emote} other {Emotes}}",
+		"emote_sets": "{count, plural, one {Emote Set} other {Emote Sets}}",
+		"users": "{count, plural, one {User} other {Users}}",
+		"channels": "{count, plural, one {Channel} other {Channels}}",
+		"followers": "{count, plural, one {Follower} other {Followers}}",
+		"items": "{count, plural, one {Item} other {Items}}",
+		"subscriptions": "{count, plural, one {Subscription} other {Subscriptions}}",
+		"payment_methods": "{count, plural, one {Payment Method} other {Payment Methods}}",
+		"date": "Date",
+		"help": "Help",
+		"for": "for",
+		"error": "Error",
+		"loading": "Loading...",
+		"paint_bundles": "Paint Bundles",
+		"notifications": "Notifications",
+		"connections": "Connections",
+		"direct_messages": "Direct Messages",
+		"mod_comments": "Mod Comments",
+		"profile_picture": "Profile Picture",
+		"suggested_emotes": "Suggested Emotes",
+		"personal_emotes": "Personal Emotes",
+		"no_more_emotes": "No more emotes",
+		"no_emotes": "No emotes",
+		"your_subscription": "Your Subscription",
+		"theme": "Theme",
+		"language": "Language",
+		"developer_portal": "Developer Portal",
+		"faq": "Frequently Asked Questions",
+		"faq_short": "FAQ",
+		"privacy": "Privacy Policy",
+		"tos": "Terms of Service",
+		"trending": "Trending",
+		"top": "Top",
+		"global": "Global",
+		"new": "New",
+		"Weekly": "Weekly",
+		"Monthly": "Monthly",
+		"Today": "Today",
+		"news": "News",
+		"Default_set": "Default Set",
+		"following": "Following",
+		"activity": "Activity",
+		"info": "Info",
+		"analytics": "Analytics",
+		"statistics": "Statistics",
+		"contact": "Contact",
+		"cosmetics": "Cosmetics",
+		"editors": "Editors",
+		"active": "Active",
+		"profile": "Profile",
+		"pinned": "Pinned",
+		"settings": "Settings",
+		"delete_account": "Delete Account"
+	},
+	"labels": {
+		"enter_text": "Enter text",
+		"redeem": "Enter code",
+		"search": "Search",
+		"refetch": "Refetch",
+		"manage_connections": "Manage Connections",
+		"manage_editors": "Manage Editors",
+		"none": "None",
+		"search_user": "Search User",
+		"search_country": "Search Country",
+		"search_emote_set": "Search Emote Set",
+		"search_users": "{count, plural, one {Search a user} other {Search users}}",
+		"tags": "Tags",
+		"close": "Close",
+		"contribute": "Contribute",
+		"enter_tags": "Enter tags",
+		"tag_limit_reached": "Tag limit of {limit} reached",
+		"filters": "Filters",
+		"no_filters": "No Filters",
+		"emote_name": "Emote Name",
+		"copy_link": "Copy Link",
+		"create_emote_set": "Create New Set",
+		"emote_set_name": "Emote Set Name",
+		"emote_attribution": "Emote Attribution",
+		"select": "Select",
+		"selection_mode": "Selection Mode",
+		"edit": "Edit",
+		"capacity": "Capacity",
+		"enable": "Enable",
+		"disable": "Disable",
+		"disabled": "Disabled",
+		"more": "More",
+		"actions": "Actions",
+		"download": "Download",
+		"report": "Report",
+		"delete": "Delete",
+		"time_select": {
+			"week": "This Week",
+			"month": "This Month",
+			"year": "This Year"
+		},
+		"gift": "Gift",
+		"follow": "Follow",
+		"connect": "Connect",
+		"disconnect": "Disconnect",
+		"email": "Email",
+		"password": "Password",
+		"all": "All",
+		"other": "Other",
+		"cancel": "Cancel",
+		"confirm": "Confirm",
+		"proceed": "Proceed",
+		"save": "Save",
+		"remove": "Remove",
+		"accept": "Accept",
+		"deny": "Deny",
+		"enter": "Enter"
+	},
+	"themes": {
+		"system": "System",
+		"dark": "Dark",
+		"light": "Light"
+	},
+	"flags": {
+		"global": "Global",
+		"trending": "Trending",
+		"overlaying": "Overlaying",
+		"default": "Default",
+		"personal": "Personal",
+		"listed": "Listed",
+		"unlisted": "Unlisted",
+		"personal_use": "Personal Use",
+		"deleted": "Deleted",
+		"private": "Private",
+		"personal_use_approved": "Approved Personal Use",
+		"personal_use_denied": "Denied Personal Use",
+		"personal_use_pending": "Personal Use Pending Review",
+		"renamed": "Renamed",
+		"nsfw": "NSFW",
+		"editor_flags": {
+			"pending": "Pending",
+			"accepted": "Accepted",
+			"rejected": "Rejected",
+			"you_accepted": "You Accepted",
+			"you_rejected": "You Rejected"
+		}
+	},
+	"notifications": {
+		"system": "System",
+		"approved_for_public": "Your emote {emote} has been approved for public listing."
+	},
+	"sub_info": {
+		"plan": "Plan",
+		"free": "Free",
+		"gifted_by": "Gifted by",
+		"ends": "Sub Ends",
+		"total": "Total",
+		"credits": "Sub Credits"
+	},
+	"file_limits": {
+		"max_size": "{size} max file size",
+		"max_resolution": "{width}x{height} max resolution",
+		"max_frames": "{count} max frames",
+		"resolution_error": "Resolution must not exceed {width}x{height}",
+		"duration_error": "Duration must be {duration} seconds or less"
+	},
+	"dialogs": {
+		"sign_in": {
+			"title": "Sign in to 7TV",
+			"subtitle": "Sign in or create an account to continue",
+			"continue_with": "Continue with {platform}",
+			"trouble": "Trouble signing in?",
+			"legal_yapping": "By signing in, you agree to our",
+			"and": "and",
+			"linking_new": "Already have a 7TV account and plan on linking a new connection? Sign in with your existing connection and link the new one in the",
+			"settings": "settings"
+		},
+		"search": {
+			"emotes": "Emotes",
+			"users": "Users"
+		},
+		"upload": {
+			"title": "Upload Emote",
+			"untitled": "Untitled",
+			"chat": "Send a message",
+			"drag_drop": "Drag & Drop to upload, or",
+			"browse_files": "Browse Files",
+			"accept_rules": "I accept the rules and guidelines",
+			"discard": "Discard",
+			"upload_guidelines": "Emote Upload Guidelines",
+			"upload": "Upload"
+		},
+		"emote_set": {
+			"title": "Active Emote Set",
+			"create": "Create Emote Set",
+			"name": "Emote Set Name",
+			"label": "Name",
+			"confirm": "Create",
+			"copy_set": "Copy Set",
+			"special": "Special",
+			"favourite_sets": {
+				"title": "Favorite Emote Sets",
+				"add": "Add & Rename to all",
+				"remove": "Remove from all"
+			},
+			"mass_select_feature": {
+				"add": "Add to Emote-Set",
+				"remove": "Remove from Emote-Set",
+				"amount_selected_label": "/20 Selected"
+			},
+			"default_emote_set": {
+				"remove": "Remove Emote from {set}",
+				"add": "Add Emote to {set}",
+				"conflicting_name": "Conflicting Name"
+			}
+		},
+		"manage_aliases": {
+			"title": "Manage Emote Aliases",
+			"add_placeholder": "Add new alias.."
+		},
+		"rename_emote": {
+			"title": "Rename Emote in {set}",
+			"input_placeholder": "New emote name",
+			"confirmation_message": "Are you sure you want to rename this emote in {set}?",
+			"confirm": "Rename"
+		},
+		"remove_emote_from_set": {
+			"title": "Remove Emote from {set}",
+			"warning_message": "Are you sure you want to remove {emote} from {set}?",
+			"confirm": "Remove"
+		},
+		"add_emote": {
+			"title": "Add {emote} to",
+			"change_name": "Change emote name",
+			"confirm": "Confirm",
+			"confirm_changes": "{count, plural, one {Confirm 1 change} other {Confirm {count} changes}}"
+		},
+		"emote_ticket": {
+			"emote_queue": "Emote queue",
+			"activity": "Activity",
+			"comments": "Comments"
+		},
+		"emote_context_menu": {
+			"add_remove_emote": "Add/Remove Emote",
+			"edit_emote_alias": "Edit Emote Alias",
+			"remove_emote": "Remove Emote From Set",
+			"open_in_new_tab": "Open in New Tab",
+			"copy_emote_link": "Copy Emote Link"
+		},
+		"cart": {
+			"title": "Your Cart",
+			"duration": "Duration",
+			"price": "Price",
+			"preview": "Preview",
+			"purchase_as_gift": "Purchase as a gift",
+			"total": "Total"
+		},
+		"editor": {
+			"permissions": "Set Editor Permissions",
+			"super_admin": "Super Admin",
+			"emote_sets": "Emote Sets",
+			"admin": "Admin",
+			"emotes": "Emotes",
+			"user": "User",
+			"manage_personal_emotes": "Manage Personal Emote Set",
+			"confirm": "Confirm",
+			"no_editors": "No editors to show",
+			"permissions_details": {
+				"manage": "Manage",
+				"create": "Create",
+				"transfer": "Transfer",
+				"manage_profile": "Manage Profile",
+				"manage_emotes": "Manage Emotes",
+				"manage_billing": "Manage Billing",
+				"manage_editors": "Manage Editors",
+				"view_billing": "View Billing Information"
+			}
+		},
+		"emote_info": {
+			"processing": "This emote is still processing",
+			"refresh": "Refresh",
+			"download": "Download"
+		},
+		"copy_emotes": {
+			"title": "Copy selected emotes to"
+		},
+		"default_set": {
+			"title": "Default Emote Set"
+		},
+		"delete_account": {
+			"warning": "Warning",
+			"warning_message": "This action will delete your account permanently. You cannot undo this action.",
+			"choose_reasons": "Choose the reasons for account deletion",
+			"reasons": {
+				"no_longer_use": "I no longer use 7TV",
+				"privacy_concerns": "Privacy concerns",
+				"not_useful": "Not useful",
+				"other": "Other"
+			},
+			"confirm_username": "Enter your username to confirm"
+		},
+		"delete_emote_or_set": {
+			"title": "Delete {name}",
+			"warning_message_emote": "This will delete your emote permanently. You cannot undo this action.",
+			"warning_message_set": "This will delete your emote set permanently. You cannot undo this action.",
+			"reason": "Reason",
+			"reason_for_deletion": "Reason for deletion"
+		},
+		"edit_emote": {
+			"title": "Edit {emote}"
+		},
+		"edit_emote_set": {
+			"title": "Edit Emote Set",
+			"show_on_profile": "Show on Profile",
+			"publicly_listed": "Publicly Listed"
+		},
+		"remove_emote": {
+			"title": "Remove selected emotes from {set}"
+		},
+		"report_emote": {
+			"title": "Report Emote",
+			"choose_reasons": "Choose the reasons",
+			"reasons": {
+				"my_work": "I made this emote but it was uploaded by someone else",
+				"duplicate": "This emote is a duplicate",
+				"sexual": "This emote contains pornographic or overly sexualized imagery",
+				"violance": "This emote displays extreme violence or gore",
+				"its_me": "This emote depicts me and I don't like it",
+				"offensive": "I find this emote offensive",
+				"other": "Other"
+			},
+			"additional_info": "Additional Information",
+			"disclaimer": "Abuse of the report feature may lead to your access being revoked."
+		},
+		"transfer_emote": {
+			"title": "Transfer {emote}",
+			"details": "This will transfer {emote}.",
+			"receipient": "Emote Receipient",
+			"transfer": "Transfer"
+		},
+		"badge": {
+			"title": "Badge"
+		},
+		"subscription": {
+			"gifted_by": "Your subscription was gifted to you by",
+			"cancel_notice": "Ending your subscription now will make you lose access to your subscription benefits immediately. Are you sure you want to end your subscription?",
+			"cancel_confirmation": "Are you sure you want to cancel your subscription? You will lose access to your subscription benefits at the end of your current billing period.",
+			"confirm": "Confirm"
+		},
+		"error": {
+			"title": "Error"
+		},
+		"pickems": {
+			"gift": {
+				"title": "Gift Pick'ems Pass",
+				"gift_to": "Gift Pick'ems Pass to",
+				"recipient": "Select recipient",
+				"back": "Back",
+				"continue": "Continue"
+			}
+		},
+		"gift": {
+			"title": "Gift 1",
+			"gift_to": "Gift 1 {variant} to",
+			"recipient": "Select recipient"
+		},
+		"paint": {
+			"title": "Paint"
+		},
+		"buttons": {
+			"back": "Back",
+			"continue": "Continue"
+		},
+		"emote-events": {
+			"upload": {
+				"action": "Uploaded"
+			},
+			"process": {
+				"start": "Started a new processing job",
+				"success": "Successfully finished processing",
+				"fail": "Failed processing",
+				"cancel": "Cancelled processing job"
+			},
+			"change_name": {
+				"action": "Renamed"
+			},
+			"merge": {
+				"action": "Merged"
+			},
+			"change_owner": {
+				"action": "Transferred ownership"
+			},
+			"change_tags": {
+				"action": "Set tags to"
+			},
+			"change_flags": {
+				"approved_public": {
+					"action": "Approved for public listing"
+				},
+				"removed_public": {
+					"action": "Removed from public listing"
+				},
+				"approved_personal": {
+					"action": "Approved for personal use"
+				},
+				"rejected_personal": {
+					"action": "Rejected for personal use"
+				},
+				"added_overlaying": {
+					"action": "Added flag overlaying"
+				},
+				"removed_overlaying": {
+					"action": "Removed flag overlaying"
+				},
+				"added_private": {
+					"action": "Added flag private"
+				},
+				"removed_private": {
+					"action": "Removed flag private"
+				}
+			},
+			"delete": {
+				"action": "Deleted"
+			}
+		}
+	},
+	"pages": {
+		"activity": {
+			"title": "Activity",
+			"emote": {
+				"deleted_emote": "Deleted Emote",
+				"deleted_set": "Deleted Set",
+				"by": "by",
+				"created": "Created",
+				"changed_tags": "Changed tags for",
+				"changed_capacity": "Changed capacity for",
+				"added": "Added",
+				"removed": "Removed emote",
+				"renamed": "Renamed emote",
+				"in": "in",
+				"from": "from",
+				"to": "to",
+				"deleted": "Deleted"
+			},
+			"user": {
+				"changed_paint": "Changed active paint from",
+				"changed_badge": "Changed active badge from",
+				"removed": "Removed",
+				"connection": "Connection",
+				"changed_set": "Changed active emote set from",
+				"added": "Added",
+				"no_badge": "No Badge",
+				"no_paint": "No Paint",
+				"deleted": "Deleted"
+			}
+		},
+		"auth": {
+			"title": {
+				"logging": "Logging you in...",
+				"logged": "Logged in",
+				"failed": "Failed to log in"
+			},
+			"state": {
+				"logging": "Logging you in...",
+				"logged": "Logged in",
+				"failed": {
+					"title": "Login Failed",
+					"message": "Make sure to open this window through the extension"
+				}
+			}
+		},
+		"home": {
+			"title": "Home",
+			"features": {
+				"emote_slots": "1000 Emote Slots",
+				"emote_slots_info": "Everyone gets 1000 customizable channel emote slots, all for free. Keep all your emotes in one place.",
+				"emote_slots_button": "Browse Emotes",
+				"emote_sets": "Emote Sets",
+				"emote_sets_info": "Group emotes in customizable sets that can be shared with other users or quickly swapped onto your channel.",
+				"emote_sets_button": "Create an Emote Set",
+				"custom_emotes": "Custom Emote Names",
+				"custom_emotes_info": "Don't like the name given to an emote by its author? That's fine, you can change it for your channel only.",
+				"custom_emotes_button": "Browse Emotes",
+				"real-time": "Real-Time Updates",
+				"real-time_info": "Changing emotes in your channel happens instantly, for all viewers. No F5 required, no more waiting.",
+				"real-time_button": "Download the Extension",
+				"large_community": "Large Community",
+				"large_community_info": "7TV serves 2,000,000+ daily unique users and has a library of over 1,000,000 public emotes.",
+				"large_community_button": "Join our Discord",
+				"next_gen": "Next-gen Formats",
+				"next_gen_info": "We use newer, more optimized image formats like WebP and AVIF, to reduce bandwidth usage.",
+				"next_gen_button": "Download the Extension"
+			}
+		},
+		"help": {
+			"title": "Help"
+		},
+		"directory": {
+			"title": "Directory",
+			"bookmarked": "Bookmarked",
+			"sorting": {
+				"title": "Sorting",
+				"alphabetical": "Alphabetical",
+				"upload_date": "Upload Date"
+			},
+			"filters": {
+				"animated": "Animated",
+				"static": "Static",
+				"overlaying": "Overlaying",
+				"personal_use": "Personal Use",
+				"exact_match": "Exact Match"
+			},
+			"size": {
+				"title": "Size",
+				"any": "Any Size"
+			}
+		},
+		"landing": {
+			"start": "Start your journey with hundreds of emotes and features that enhance your chatting experience. Download the Official 7TV Extension or other 3rd party tools.",
+			"developers": {
+				"header": "Source-Available",
+				"info": "Our entire codebase is available on GitHub with a source-available license. Anyone can view and contribute."
+			},
+			"download": {
+				"start": "Start your journey with hundreds of emotes and features that enhance your chatting experience. Download the Official 7TV Extension or other 3rd party tools.",
+				"extension": "Web Extension",
+				"recommended": "Recommended",
+				"stable": "Stable Release",
+				"nightly": "Nightly Release",
+				"chatterino": "Chatterino",
+				"mobile": {
+					"apps": "Mobile Apps"
+				},
+				"bots": {
+					"header": "Chat Bots"
+				}
+			},
+			"features": {
+				"header": "Why 7TV?",
+				"info": "Our platform offers a variety of useful features that will enhance your chatting experience."
+			},
+			"footer": {
+				"affiliated": "7TV is not affiliated with Twitch, Kick or Discord",
+				"privacy_policy": "Privacy Policy",
+				"tos": "Terms of Service"
+			},
+			"hero": {
+				"platform": "The Emote Platform",
+				"all": "for All",
+				"download": "Download",
+				"manage": "Manage hundreds of emotes for your Twitch and Kick channels with ease. Enhance your chatting experience.",
+				"more": "Learn more",
+				"xmas": {
+					"header": "X-MAS sSUB EVENT",
+					"info": "Gift 1 sub to anyone this christmas and get a special badge!",
+					"gift": "Gift a sub"
+				},
+				"nnys": {
+					"info": "Vote on NNYS 2025 to get an exclusive paint, badge & emote set.",
+					"vote": "Vote in NNYS 2025"
+				},
+				"cs2": {
+					"streamers": "35 STREAMERS",
+					"tournament": "7TV HOSTED TOURNAMENT",
+					"event": "3 DAY EVENT",
+					"header": "Place your Pick'ems. Win Prizes.",
+					"info": "7TV Hoster CS2 Tournament",
+					"date": "Feb. 29th - Mar. 2nd",
+					"pickems": "Place your pick'ems",
+					"pass": "Get the pass!",
+					"badges_paints": "Win Badges & Paints.",
+					"description1": "xQc, OhnePixel, JasonTheWeen and 32 other streamers go head to head",
+					"description2": "in a 3-day Single Elimination 7TV Hosted CS2 tournament."
+				}
+			}
+		},
+		"discover": {
+			"title": "Discover",
+			"uploads": "Uploads",
+			"followed": "Followed accounts"
+		},
+		"store": {
+			"title": "Store",
+			"redeem": {
+				"title": "Redeem",
+				"header": "Redeem a Gift Code",
+				"subtitle": "Redeem a gift code to unlock exclusive cosmetics and benefits.",
+				"state": {
+					"idle": "Idle",
+					"loading": "Loading",
+					"success": "Success"
+				},
+				"code": "code",
+				"shown": "shown",
+				"trial": "You successfully redeemed your trial subscription"
+			},
+			"purchase": {
+				"success": "Your purchase was successfully completed"
+			},
+			"subscription": {
+				"banner_title_subbed": "Thank You For the Support",
+				"banner_title_unsubbed": "Unlock Special Perks",
+				"banner_subtitle_subbed": "Enjoy Your Special Subscriber Perks!",
+				"banner_subtitle_unsubbed": "Subscribe to Enhance Your Chatting Experience.",
+				"badge_progress": {
+					"title": "Badge Progress",
+					"left": "{duration} left"
+				},
+				"benefits": {
+					"title": "Subscription Benefits",
+					"animated_avatar": "Animated Profile Picture",
+					"personal_emotes": "Personal Emotes",
+					"paints": "Nametag Paints",
+					"sub_badge": "Subscriber Badge",
+					"raffle_tickets": "Raffle Tickets"
+				},
+				"raffle": "Global Emote Raffle",
+				"monthly_paints": "Monthly Paints",
+				"your_cosmetics": "Your Cosmetics",
+				"your_paints": "Your Paints",
+				"beomce_a_subscriber": "Become a Subscriber",
+				"your_badges": "Your Badges",
+				"top_gifters": "Top Gifters",
+				"subscribe": "Subscribe",
+				"subscribed": "Subscribed",
+				"cancel": "Cancel Subscription",
+				"reactivate": "Reactivate Subscription",
+				"one_monhth": "1 Month",
+				"one_year": "1 Year"
+			},
+			"paint_bundles": {
+				"coming_soon": "Coming Soon",
+				"banner_title": "Make Yourself Glow",
+				"banner_subtitle": "Nametag Paints Will Let You Express Yourself in Every Hue."
+			},
+			"events": {
+				"no_events": "No upcoming events",
+				"xmas": "X-MAS 2024 EVENT: GIFT 1 SUB TO GET A SPECIAL BADGE",
+				"cs2": {
+					"tournament": "7TV Hosted CS2 Tournament",
+					"cosmetics": "Want to earn cosmetics for predicting the outcome? Click below!",
+					"twitch": "VIEW TWITCH",
+					"bundle": "Purchase Bundle",
+					"already_subscribed": "Already Subscribed",
+					"subscribe": "{price} today, then {recurring}",
+					"billing_cycle": "Billed as one-time purchase",
+					"pickems": {
+						"place": "Place Pick'ems",
+						"predict": "Predict Winners",
+						"purchase_pass": "Purchase Pass"
+					},
+					"pass": {
+						"title": "Pick'ems Pass",
+						"get": "Get Pass",
+						"bundle": "Pass + {variantName(variant)} Subscription Bundle"
+					},
+					"schedule": {
+						"header": "Tournament Schedule",
+						"stage": "Stage",
+						"best_of": "Best of",
+						"start_time": "Start Time"
+					},
+					"streamers": {
+						"header": "Meet the Streamers",
+						"info": "A prominent line-up of Twitch Streamers build a team from their communities who go head-to-head in a CS-Style Single Elimination Tournament.",
+						"watch": "Watch the main event on the",
+						"twitch_channel": "7TV Twitch Channel",
+						"streamer_pov": "or through your favourite streamer's POV."
+					}
+				}
+			}
+		},
+		"admin": {
+			"title": "Admin",
+			"overview": "Overview",
+			"welcome": "Welcome back",
+			"enjoy": "Enjoy modding!",
+			"tickets": {
+				"title": "Tickets",
+				"emotes": {
+					"public_listing": "Public Listing",
+					"personal_use": "Personal Use",
+					"resolved": "Resolved",
+					"not_implemented": "Not Implemented"
+				},
+				"emote_table": {
+					"emote_name": "Emote Name",
+					"uploader": "Uploader",
+					"country": "Country",
+					"tags_flags": "Tags & Flags",
+					"reviewed_by": "Reviewed By"
+				},
+				"reports": "Reports",
+				"reports_options": {
+					"all": "All",
+					"assigned": "Assigned",
+					"closed": "Closed"
+				},
+				"reports_table": {
+					"reported_by": "Reported by",
+					"target": "Target",
+					"description": "Description",
+					"assigned_to": "Assigned to",
+					"status": "Status",
+					"date": "Date",
+					"ticket_id": "Ticket ID",
+					"subject": "Subject",
+					"details": "Details"
+				},
+				"reports_actions": {
+					"close": "Mark as Closed",
+					"assign_self": "Assign Self",
+					"add_comment": "Add comment"
+				}
+			},
+			"codes": {
+				"redeem": "Redeem Codes",
+				"add": "Add Code(s)",
+				"filters": {
+					"header": "Filters:",
+					"remaining_uses": "Remaining Uses"
+				},
+				"search": {
+					"results": "Found {results.totalCount} results ({results.pageCount} pages)"
+				},
+				"attributes": {
+					"name": {
+						"name": "Name",
+						"description": "Description",
+						"tags": "Tags",
+						"code": "Code",
+						"remaining_uses": "Remaining Uses",
+						"active_period": "Active Period",
+						"effect": "Effect",
+						"subscription_effect": "Subscription Effect",
+						"created_by": "Created By",
+						"created_at": "Created At",
+						"actions": "Actions"
+					}
+				},
+				"period": {
+					"unlimited": "Unlimited"
+				},
+				"trial": {
+					"days": "days trial",
+					"no_trial": "No trial",
+					"none": "None"
+				},
+				"system": "System"
+			},
+			"special_events": {
+				"header": "Special Events",
+				"create": "Create Special Event",
+				"add": "Add Special Event",
+				"results": "Found {results.length} results",
+				"attributes": {
+					"name": "Name",
+					"description": "Description",
+					"tags": "Tags",
+					"created_by": "Created By",
+					"created_at": "Created At",
+					"actions": "Actions",
+					"create": "Create",
+					"cancel": "Cancel"
+				},
+				"system": "System",
+				"no_events": "No Special Events"
+			},
+			"users": {
+				"id": {
+					"back": "Back",
+					"last_updated": "Last Updated At",
+					"search_last_update": "Search Last Updated At",
+					"queued": "Queued for update",
+					"stripe": {
+						"customer": "Stripe Customer",
+						"view": "View",
+						"no_customer": "No stripe customer associated",
+						"roles": "Roles"
+					},
+					"actions": {
+						"header": "Actions",
+						"sessions": {
+							"header": "Sessions",
+							"create_session": "Create New Session",
+							"delete_all": "Delete All Sessions",
+							"expiration": "Expiration date in",
+							"token": "Token",
+							"copy_token": "Copy Token",
+							"create": "Create",
+							"close": "Close"
+						},
+						"connections": {
+							"header": "Connections",
+							"kick": "Manually Link Kick",
+							"username": "Kick Username"
+						},
+						"entitlements": {
+							"header": "Entitlements",
+							"create": "Create Entitlements",
+							"assign": "Manually Assign Entitlements",
+							"assign_to": "Assign entitlements to",
+							"remove_all": "Remove All Entitlements",
+							"view": "View Entitlements",
+							"showing": "Showing entitlements assigned to"
+						}
+					},
+					"subscription": {
+						"header": "Subscription",
+						"period": {
+							"header": "Subscription Periods",
+							"key": "Key",
+							"value": "Value",
+							"id": "ID"
+						},
+						"copy": {
+							"ulid": "Copy ULID",
+							"uuid": "Copy UUID"
+						},
+						"provider": {
+							"id": "Provider ID",
+							"view": "View"
+						},
+						"product": {
+							"id": "Product ID",
+							"view": "View",
+							"start": "Start",
+							"end": "End",
+							"is_trial": "Is Trial?",
+							"auto_renew": "Auto Renew?",
+							"gifted": {
+								"header": "Gifted?",
+								"yes": "Yes - By",
+								"no": "No"
+							},
+							"created_by": "Created By",
+							"redeem": "Redeem Code",
+							"invoice": "Invoice",
+							"system": "System",
+							"variant": "Product Variant"
+						}
+					},
+					"not_found": "User not found"
+				},
+				"layout": {
+					"users": "Users"
+				},
+				"page": {
+					"manage": {
+						"header": "Manage",
+						"single_user": "Manage a single user"
+					},
+					"actions": {
+						"header": "Actions",
+						"sub_benefits_job": {
+							"header": "Subscription Benefits Job",
+							"manually": "Manually trigger the subscription job to recalculate entitlements and subscription benefits for all users.",
+							"rerun": "Rerun"
+						}
+					}
+				}
+			}
+		},
+		"emote": {
+			"use_emote": "Use Emote",
+			"add_to": "Add to...",
+			"transfer": "Transfer",
+			"merge": "Merge",
+			"size": "Size",
+			"copy_link": "Copy Link",
+			"info": {
+				"used_by_channels": "Channels using this emote",
+				"channels_tooltip": "Number of channels that currently have this emote active in one of their emote sets.",
+				"trending_this_week": "Trending rank this week",
+				"trending_tooltip": "Position among 7TV's top ~500 emotes by recent growth.",
+				"top_all_time": "Top rank all-time",
+				"top_all_time_tooltip": "Position among 7TV's top ~500 emotes by total net channel adoption.",
+				"not_ranked": "Not currently ranked",
+				"raw_score": "Growth score: {score}",
+				"stats_error": "Couldn't load channel/ranking stats.",
+				"usage_note": "7TV doesn't track how many times an emote is actually sent in chat. The numbers above show how many channels have added this emote and how it ranks in 7TV's trending/top lists."
+			}
+		},
+		"user": {
+			"about": "About",
+			"active_emotes": "Active Emotes",
+			"uploaded": "Uploaded",
+			"uploaded_emotes": "Uploaded Emotes"
+		},
+		"settings": {
+			"account": {
+				"title": "Account",
+				"profile": {
+					"details": "Customize preferences and manage details to suit your individual needs",
+					"display_name": "Display Name",
+					"display_name_description": "Choose a main connection that will be used for your display name and static profile picture",
+					"profile_picture_description": "Choose a profile picture that will be displayed on all platforms",
+					"update_profile_picture": "Update Profile Picture"
+				},
+				"connections": {
+					"details": "Manage and link external accounts to streamline access and enhance interoperability within the platform"
+				},
+				"security": {
+					"title": "Security",
+					"details": "Manage and customize your account security",
+					"2fa": "Two Factor Authentication",
+					"2fa_details": "Enhance the security of your account with Two-Factor Authentication (2FA)",
+					"email_details": "Receive a verification code via email",
+					"authenticator_app": "Authenticator App",
+					"authenticator_app_details": "Install an app to generate your verification code",
+					"sign_out_everywhere": "Sign Out Everywhere",
+					"sign_out_everywhere_details": "Ensure security and log out from all devices with a single click",
+					"delete_account_details": "Permanently remove all personal information and associated data from the platform, terminating your account"
+				}
+			},
+			"appearance": {
+				"title": "Appearance",
+				"details": "Change the look and feel",
+				"theme": {
+					"header": "Theme",
+					"options": {
+						"system": "System",
+						"dark": "Dark",
+						"light": "Light"
+					}
+				},
+				"motion": {
+					"header": "Reduced Motion",
+					"options": {
+						"system": "System",
+						"enabled": "Enabled",
+						"disbaled": "Disabled"
+					}
+				},
+				"right-to-left-layout": {
+					"header": "Website Direction Layout",
+					"options": {
+						"ltr": "Left to Right",
+						"rtl": "Right to Left"
+					}
+				}
+			},
+			"editors": {
+				"details": "Manage and customize your editors or channels you edit for",
+				"editing_for": "Editing For",
+				"add_editor": "Add Editor",
+				"not_allowed": "You are not allowed to manage editors for this user"
+			},
+			"notifications": {
+				"details": "Real-time updates and alerts, keeping users informed about important events, messages, and activities within the website or application"
+			},
+			"blocked": {
+				"title": "Blocked",
+				"details": "Manage your restricted or prohibited content, users, or activities",
+				"add_user": "Add Blocked User"
+			},
+			"billing": {
+				"title": "Billing",
+				"subscription": {
+					"details": "Lorem ipsum dolor sit, amet consectetur adipisicing elit. Magni incidunt numquam itaque, amet ad, pariatur possimus illo atque sunt asperiores molestias autem ex nobis consequuntur culpa. Corporis possimus aspernatur soluta.",
+					"use_credits": "Use Subscription Credits",
+					"use_credits_details": "Your subscription credits will be used first for your next billing",
+					"cancelled": "Subscription Cancelled",
+					"cancelled_details": "Your subscription has been cancelled and your benefits will expire on {date}"
+				},
+				"history": {
+					"title": "Billing History",
+					"details": "See all payment activities associated with your account, such as past billing statements and transactions"
+				},
+				"payment_methods": {
+					"details": "Check and update your preferred payment methods",
+					"add_new": "Add New",
+					"card": {
+						"title": "Card Info",
+						"ends_in": "Ends in {digits}",
+						"expires": "Expires {month}/{year}",
+						"address": "Address",
+						"name": "Name"
+					}
+				},
+				"table": {
+					"status": "Status",
+					"amount": "Amount",
+					"invoice": "Invoice"
+				}
+			},
+			"user_table": {
+				"name": "Name",
+				"last_modified": "Last Modified",
+				"permissions": "Permissions"
+			}
+		},
+		"link": {
+			"linking": "Linking Your Account...",
+			"linking_successful": "Account Successfully Linked",
+			"linking_failed": "Linking Failed"
+		},
+		"extension": {
+			"login": "Logging you in...",
+			"login_successful": "Logged in",
+			"login_failed": "Failed to log in",
+			"window": "Make sure to open this window through the extension"
+		}
+	}
 }

--- a/apps/website/src/locales/en.json
+++ b/apps/website/src/locales/en.json
@@ -908,11 +908,13 @@
 				"used_by_channels": "Channels using this emote",
 				"channels_tooltip": "Number of channels that currently have this emote active in one of their emote sets.",
 				"trending_this_week": "Trending rank this week",
-				"trending_tooltip": "Position among 7TV's top ~500 emotes by recent growth.",
+				"trending_tooltip": "Live position by recent growth under the top 500 emotes.",
 				"top_all_time": "Top rank all-time",
-				"top_all_time_tooltip": "Position among 7TV's top ~500 emotes by total net channel adoption.",
+				"top_all_time_tooltip": "Live position by total net channel adoption under the top 500 emotes.",
 				"not_ranked": "Not currently ranked",
-				"raw_score": "Growth score: {score}",
+				"trending_list_empty": "No emotes found.",
+				"trending_list_error": "Couldn't load the list.",
+				"trending_list_load_more": "Load more",
 				"stats_error": "Couldn't load channel/ranking stats.",
 				"usage_note": "7TV doesn't track how many times an emote is actually sent in chat. The numbers above show how many channels have added this emote and how it ranks in 7TV's trending/top lists."
 			}

--- a/apps/website/src/routes/emotes/[id]/activity/+page.svelte
+++ b/apps/website/src/routes/emotes/[id]/activity/+page.svelte
@@ -6,14 +6,24 @@
 	import Spinner from "$/components/spinner.svelte";
 	import EmoteEventComponent from "$/components/events/emote-event.svelte";
 	import type { EmoteEvent } from "$/gql/graphql";
+	import { t } from "svelte-i18n";
 
 	let { data }: { data: PageData } = $props();
 
 	async function loadEvents(id: string) {
+		try {
+			return await loadEventsUnsafe(id);
+		} catch (error) {
+			console.error("Failed to load emote activity", error);
+			throw error;
+		}
+	}
+
+	async function loadEventsUnsafe(id: string) {
 		const res = await gqlClient()
 			.query(
 				graphql(`
-					query EmoteEvents($id: Id!) {
+					query EmoteActivityEvents($id: Id!) {
 						emotes {
 							emote(id: $id) {
 								events {
@@ -23,6 +33,77 @@
 										id
 										mainConnection {
 											platformDisplayName
+											platformAvatarUrl
+										}
+										style {
+											activeProfilePicture {
+												images {
+													url
+													mime
+													size
+													width
+													height
+													scale
+													frameCount
+												}
+											}
+											activePaint {
+												id
+												name
+												data {
+													layers {
+														id
+														ty {
+															__typename
+															... on PaintLayerTypeSingleColor {
+																color {
+																	hex
+																}
+															}
+															... on PaintLayerTypeLinearGradient {
+																angle
+																repeating
+																stops {
+																	at
+																	color {
+																		hex
+																	}
+																}
+															}
+															... on PaintLayerTypeRadialGradient {
+																repeating
+																stops {
+																	at
+																	color {
+																		hex
+																	}
+																}
+																shape
+															}
+															... on PaintLayerTypeImage {
+																images {
+																	url
+																	mime
+																	size
+																	scale
+																	width
+																	height
+																	frameCount
+																}
+															}
+														}
+														opacity
+													}
+													shadows {
+														color {
+															hex
+														}
+														offsetX
+														offsetY
+														blur
+													}
+												}
+											}
 										}
 										highestRoleColor {
 											hex
@@ -48,6 +129,77 @@
 												id
 												mainConnection {
 													platformDisplayName
+													platformAvatarUrl
+												}
+												style {
+													activeProfilePicture {
+														images {
+															url
+															mime
+															size
+															width
+															height
+															scale
+															frameCount
+														}
+													}
+													activePaint {
+														id
+														name
+														data {
+															layers {
+																id
+																ty {
+																	__typename
+																	... on PaintLayerTypeSingleColor {
+																		color {
+																			hex
+																		}
+																	}
+																	... on PaintLayerTypeLinearGradient {
+																		angle
+																		repeating
+																		stops {
+																			at
+																			color {
+																				hex
+																			}
+																		}
+																	}
+																	... on PaintLayerTypeRadialGradient {
+																		repeating
+																		stops {
+																			at
+																			color {
+																				hex
+																			}
+																		}
+																		shape
+																	}
+																	... on PaintLayerTypeImage {
+																		images {
+																			url
+																			mime
+																			size
+																			scale
+																			width
+																			height
+																			frameCount
+																		}
+																	}
+																}
+																opacity
+															}
+															shadows {
+																color {
+																	hex
+																}
+																offsetX
+																offsetY
+																blur
+															}
+														}
+													}
 												}
 												highestRoleColor {
 													hex
@@ -57,6 +209,77 @@
 												id
 												mainConnection {
 													platformDisplayName
+													platformAvatarUrl
+												}
+												style {
+													activeProfilePicture {
+														images {
+															url
+															mime
+															size
+															width
+															height
+															scale
+															frameCount
+														}
+													}
+													activePaint {
+														id
+														name
+														data {
+															layers {
+																id
+																ty {
+																	__typename
+																	... on PaintLayerTypeSingleColor {
+																		color {
+																			hex
+																		}
+																	}
+																	... on PaintLayerTypeLinearGradient {
+																		angle
+																		repeating
+																		stops {
+																			at
+																			color {
+																				hex
+																			}
+																		}
+																	}
+																	... on PaintLayerTypeRadialGradient {
+																		repeating
+																		stops {
+																			at
+																			color {
+																				hex
+																			}
+																		}
+																		shape
+																	}
+																	... on PaintLayerTypeImage {
+																		images {
+																			url
+																			mime
+																			size
+																			scale
+																			width
+																			height
+																			frameCount
+																		}
+																	}
+																}
+																opacity
+															}
+															shadows {
+																color {
+																	hex
+																}
+																offsetX
+																offsetY
+																blur
+															}
+														}
+													}
 												}
 												highestRoleColor {
 													hex
@@ -114,12 +337,15 @@
 			<Spinner />
 		</div>
 	{:then events}
-		{#each events as event, index}
-			<EmoteEventComponent {event} />
-			{#if index !== events.length - 1}
-				<hr />
-			{/if}
-		{/each}
+		{#if events.length === 0}
+			<p class="empty">{$t("pages.emote.activity.empty")}</p>
+		{:else}
+			{#each events as event}
+				<EmoteEventComponent {event} />
+			{/each}
+		{/if}
+	{:catch}
+		<p class="empty error">{$t("pages.emote.activity.error")}</p>
 	{/await}
 </div>
 
@@ -137,5 +363,16 @@
 
 	.events {
 		margin-top: 1.5rem;
+	}
+
+	.empty {
+		color: var(--text-light);
+		font-size: 0.85rem;
+		text-align: center;
+		padding: 2rem 0;
+	}
+
+	.empty.error {
+		color: var(--danger);
 	}
 </style>

--- a/apps/website/src/routes/emotes/[id]/info/+page.svelte
+++ b/apps/website/src/routes/emotes/[id]/info/+page.svelte
@@ -1,14 +1,26 @@
 <script lang="ts">
 	import EmoteTabs from "$/components/layout/emote-tabs.svelte";
+	import TrendingEmotesDialog from "$/components/dialogs/trending-emotes-dialog.svelte";
+	import { type DialogMode } from "$/components/dialogs/dialog.svelte";
 	import type { PageData } from "./$types";
 	import { gqlClient } from "$/lib/gql";
 	import { graphql } from "$/gql";
-	import type { EmoteScores } from "$/gql/graphql";
+	import { SortBy, type EmoteScores } from "$/gql/graphql";
 	import { t } from "svelte-i18n";
 	import { numberFormat, exactNumberFormat } from "$/lib/utils";
 	import { Users, ChartLineUp, Trophy } from "phosphor-svelte";
 
 	let { data }: { data: PageData } = $props();
+
+	let dialogMode: DialogMode = $state("hidden");
+	let dialogSortBy: SortBy = $state(SortBy.TrendingWeekly);
+	let dialogTitle = $state("");
+
+	function openTrendingDialog(sortBy: SortBy, title: string) {
+		dialogSortBy = sortBy;
+		dialogTitle = title;
+		dialogMode = "shown";
+	}
 
 	type InfoStats = {
 		channelCount: number;
@@ -45,8 +57,6 @@
 									trendingWeek
 									trendingMonth
 								}
-								trendingWeekRank: ranking(ranking: TRENDING_WEEKLY)
-								topAllTimeRank: ranking(ranking: TOP_ALL_TIME)
 							}
 						}
 					}
@@ -59,12 +69,70 @@
 			throw res.error;
 		}
 
+		const scores = res.data.emotes.emote.scores;
+
+		// compute the displayed rank from the exact same live-sorted list the "view list"
+		// dialog uses, instead of the separately (once-a-day) cached ranking() field, so the
+		// number shown here always matches what you see when you click through to the list
+		const [trendingWeekRank, topAllTimeRank] = await Promise.all([
+			scores.trendingWeek > 0 ? findLiveRank(SortBy.TrendingWeekly, id) : null,
+			scores.topAllTime > 0 ? findLiveRank(SortBy.TopAllTime, id) : null,
+		]);
+
 		return {
 			channelCount: res.data.emotes.emote.channels.totalCount,
-			scores: res.data.emotes.emote.scores,
-			trendingWeekRank: res.data.emotes.emote.trendingWeekRank ?? null,
-			topAllTimeRank: res.data.emotes.emote.topAllTimeRank ?? null,
+			scores,
+			trendingWeekRank,
+			topAllTimeRank,
 		};
+	}
+
+	// server allows perPage up to 250 (see EmoteQuery::search in apps/api). Two pages covers
+	// roughly the same "top ~500" scope the old ranking() cap had; beyond that we just show
+	// "not ranked" rather than paging indefinitely to find an exact number.
+	const RANK_LOOKUP_PER_PAGE = 250;
+	const RANK_LOOKUP_MAX_PAGES = 2;
+
+	async function findLiveRank(sortBy: SortBy, targetId: string): Promise<number | null> {
+		for (let page = 1; page <= RANK_LOOKUP_MAX_PAGES; page++) {
+			const res = await gqlClient()
+				.query(
+					graphql(`
+						query EmoteLiveRankLookup($sortBy: SortBy!, $page: Int!, $perPage: Int!) {
+							emotes {
+								search(
+									sort: { sortBy: $sortBy, order: DESCENDING }
+									page: $page
+									perPage: $perPage
+								) {
+									items {
+										id
+									}
+								}
+							}
+						}
+					`),
+					{ sortBy, page, perPage: RANK_LOOKUP_PER_PAGE },
+				)
+				.toPromise();
+
+			if (res.error || !res.data) {
+				throw res.error;
+			}
+
+			const items = res.data.emotes.search.items;
+			const index = items.findIndex((item) => item.id === targetId);
+
+			if (index !== -1) {
+				return (page - 1) * RANK_LOOKUP_PER_PAGE + index + 1;
+			}
+
+			if (items.length < RANK_LOOKUP_PER_PAGE) {
+				break;
+			}
+		}
+
+		return null;
 	}
 
 	let stats = $derived(loadStats(data.id));
@@ -88,8 +156,14 @@
 				<span class="label">{$t("pages.emote.info.used_by_channels")}</span>
 			</div>
 		</div>
-		{#if stats.trendingWeekRank !== null || stats.scores.trendingWeek > 0}
-			<div class="stat" title={$t("pages.emote.info.trending_tooltip")}>
+		{#if stats.trendingWeekRank !== null || (stats.scores?.trendingWeek ?? 0) > 0}
+			<button
+				type="button"
+				class="stat clickable"
+				title={$t("pages.emote.info.trending_tooltip")}
+				onclick={() =>
+					openTrendingDialog(SortBy.TrendingWeekly, $t("pages.emote.info.trending_this_week"))}
+			>
 				<ChartLineUp size="1.25rem" />
 				<div>
 					<span class="value">
@@ -100,16 +174,16 @@
 						{/if}
 					</span>
 					<span class="label">{$t("pages.emote.info.trending_this_week")}</span>
-					<span class="raw-score">
-						{$t("pages.emote.info.raw_score", {
-							values: { score: numberFormat().format(stats.scores.trendingWeek) },
-						})}
-					</span>
 				</div>
-			</div>
+			</button>
 		{/if}
-		{#if stats.topAllTimeRank !== null || stats.scores.topAllTime > 0}
-			<div class="stat" title={$t("pages.emote.info.top_all_time_tooltip")}>
+		{#if stats.topAllTimeRank !== null || (stats.scores?.topAllTime ?? 0) > 0}
+			<button
+				type="button"
+				class="stat clickable"
+				title={$t("pages.emote.info.top_all_time_tooltip")}
+				onclick={() => openTrendingDialog(SortBy.TopAllTime, $t("pages.emote.info.top_all_time"))}
+			>
 				<Trophy size="1.25rem" />
 				<div>
 					<span class="value">
@@ -120,13 +194,8 @@
 						{/if}
 					</span>
 					<span class="label">{$t("pages.emote.info.top_all_time")}</span>
-					<span class="raw-score">
-						{$t("pages.emote.info.raw_score", {
-							values: { score: numberFormat().format(stats.scores.topAllTime) },
-						})}
-					</span>
 				</div>
-			</div>
+			</button>
 		{/if}
 	{:catch}
 		<p class="stats-error">{$t("pages.emote.info.stats_error")}</p>
@@ -134,6 +203,8 @@
 </div>
 
 <p class="usage-note">{$t("pages.emote.info.usage_note")}</p>
+
+<TrendingEmotesDialog bind:mode={dialogMode} sortBy={dialogSortBy} title={dialogTitle} />
 
 <style lang="scss">
 	.navigation {
@@ -164,6 +235,18 @@
 			color: var(--primary);
 			cursor: help;
 
+			&.clickable {
+				border: none;
+				font: inherit;
+				text-align: left;
+				cursor: pointer;
+
+				&:hover,
+				&:focus-visible {
+					background-color: var(--bg-medium);
+				}
+			}
+
 			div {
 				display: flex;
 				flex-direction: column;
@@ -178,13 +261,6 @@
 			.label {
 				font-size: 0.75rem;
 				color: var(--text-light);
-			}
-
-			.raw-score {
-				margin-top: 0.2rem;
-				font-size: 0.7rem;
-				color: var(--text-light);
-				opacity: 0.75;
 			}
 		}
 	}

--- a/apps/website/src/routes/emotes/[id]/info/+page.svelte
+++ b/apps/website/src/routes/emotes/[id]/info/+page.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+	import EmoteTabs from "$/components/layout/emote-tabs.svelte";
+	import type { PageData } from "./$types";
+	import { gqlClient } from "$/lib/gql";
+	import { graphql } from "$/gql";
+	import type { EmoteScores } from "$/gql/graphql";
+	import { t } from "svelte-i18n";
+	import { numberFormat, exactNumberFormat } from "$/lib/utils";
+	import { Users, ChartLineUp, Trophy } from "phosphor-svelte";
+
+	let { data }: { data: PageData } = $props();
+
+	type InfoStats = {
+		channelCount: number;
+		scores: EmoteScores;
+		trendingWeekRank: number | null;
+		topAllTimeRank: number | null;
+	};
+
+	async function loadStats(id: string): Promise<InfoStats> {
+		try {
+			return await loadStatsUnsafe(id);
+		} catch (error) {
+			console.error("Failed to load emote info stats", error);
+			throw error;
+		}
+	}
+
+	async function loadStatsUnsafe(id: string): Promise<InfoStats> {
+		const res = await gqlClient()
+			.query(
+				graphql(`
+					query EmoteInfoStats($id: Id!) {
+						emotes {
+							emote(id: $id) {
+								channels(page: 1, perPage: 1) {
+									totalCount
+								}
+								scores {
+									topAllTime
+									topDaily
+									topWeekly
+									topMonthly
+									trendingDay
+									trendingWeek
+									trendingMonth
+								}
+								trendingWeekRank: ranking(ranking: TRENDING_WEEKLY)
+								topAllTimeRank: ranking(ranking: TOP_ALL_TIME)
+							}
+						}
+					}
+				`),
+				{ id },
+			)
+			.toPromise();
+
+		if (res.error || !res.data || !res.data.emotes.emote) {
+			throw res.error;
+		}
+
+		return {
+			channelCount: res.data.emotes.emote.channels.totalCount,
+			scores: res.data.emotes.emote.scores,
+			trendingWeekRank: res.data.emotes.emote.trendingWeekRank ?? null,
+			topAllTimeRank: res.data.emotes.emote.topAllTimeRank ?? null,
+		};
+	}
+
+	let stats = $derived(loadStats(data.id));
+</script>
+
+<div class="navigation">
+	{#await data.streamed.emote then emote}
+		<EmoteTabs id={emote.id} />
+	{/await}
+</div>
+
+<div class="stats">
+	{#await stats}
+		<div class="stat loading-animation"></div>
+		<div class="stat loading-animation"></div>
+	{:then stats}
+		<div class="stat" title={$t("pages.emote.info.channels_tooltip")}>
+			<Users size="1.25rem" />
+			<div>
+				<span class="value">{exactNumberFormat().format(stats.channelCount)}</span>
+				<span class="label">{$t("pages.emote.info.used_by_channels")}</span>
+			</div>
+		</div>
+		{#if stats.trendingWeekRank !== null || stats.scores.trendingWeek > 0}
+			<div class="stat" title={$t("pages.emote.info.trending_tooltip")}>
+				<ChartLineUp size="1.25rem" />
+				<div>
+					<span class="value">
+						{#if stats.trendingWeekRank !== null}
+							#{numberFormat().format(stats.trendingWeekRank)}
+						{:else}
+							{$t("pages.emote.info.not_ranked")}
+						{/if}
+					</span>
+					<span class="label">{$t("pages.emote.info.trending_this_week")}</span>
+					<span class="raw-score">
+						{$t("pages.emote.info.raw_score", {
+							values: { score: numberFormat().format(stats.scores.trendingWeek) },
+						})}
+					</span>
+				</div>
+			</div>
+		{/if}
+		{#if stats.topAllTimeRank !== null || stats.scores.topAllTime > 0}
+			<div class="stat" title={$t("pages.emote.info.top_all_time_tooltip")}>
+				<Trophy size="1.25rem" />
+				<div>
+					<span class="value">
+						{#if stats.topAllTimeRank !== null}
+							#{numberFormat().format(stats.topAllTimeRank)}
+						{:else}
+							{$t("pages.emote.info.not_ranked")}
+						{/if}
+					</span>
+					<span class="label">{$t("pages.emote.info.top_all_time")}</span>
+					<span class="raw-score">
+						{$t("pages.emote.info.raw_score", {
+							values: { score: numberFormat().format(stats.scores.topAllTime) },
+						})}
+					</span>
+				</div>
+			</div>
+		{/if}
+	{:catch}
+		<p class="stats-error">{$t("pages.emote.info.stats_error")}</p>
+	{/await}
+</div>
+
+<p class="usage-note">{$t("pages.emote.info.usage_note")}</p>
+
+<style lang="scss">
+	.navigation {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+	}
+
+	.stats {
+		margin-top: 1.5rem;
+
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+
+		.stat {
+			flex: 1 1 10rem;
+			min-height: 3.5rem;
+
+			display: flex;
+			align-items: center;
+			gap: 0.75rem;
+
+			padding: 0.75rem 1rem;
+			background-color: var(--bg-light);
+			border-radius: 0.5rem;
+			color: var(--primary);
+			cursor: help;
+
+			div {
+				display: flex;
+				flex-direction: column;
+			}
+
+			.value {
+				font-size: 1rem;
+				font-weight: 700;
+				color: var(--text);
+			}
+
+			.label {
+				font-size: 0.75rem;
+				color: var(--text-light);
+			}
+
+			.raw-score {
+				margin-top: 0.2rem;
+				font-size: 0.7rem;
+				color: var(--text-light);
+				opacity: 0.75;
+			}
+		}
+	}
+
+	.usage-note {
+		margin-top: 0.75rem;
+		font-size: 0.75rem;
+		color: var(--text-light);
+	}
+
+	.stats-error {
+		margin-top: 0.75rem;
+		font-size: 0.75rem;
+		color: var(--danger);
+	}
+</style>


### PR DESCRIPTION
## Proposed changes

This PR restores some old 7TV emote page details, including:

- richer activity feed with user avatars/paints, icon and text colors for better overview and optimized timestamps
- new emote info tab showing an exact channel count and weekly trending/top-all-time stats for emotes

More details:
- activity entries now show the actor's avatar and full username styling (paints), not just a plain colored name (I reused the existing UserProfilePicture/UserName components)
- icons are now colored per action type (approve = green, reject/delete = red, rename/tags/upload = blue, merge = purple, unlist/lock = orange), using the same --approve/--danger/--rename/--admin-merge/--admin-unlist theme variables already used elsewhere in the admin UI
- added a colored left-border stripe per event matching the icon color
- added proper error/empty states
- timestamps now optionally show the exact date next to the relative time via a new opt-in showExact prop on FromNow

- new info tab showing exact channel count (Emote.channels.totalCount) and the emote's real trending/top-all-time rank (Emote.ranking(ranking: ...)) alongside the underlying raw growth score (Emote.scores)
- hover tooltips on each stat explaining what it actually measures (net channel adoption vs. chat-usage)

<img width="1911" height="990" alt="Screenshot 2026-07-19 190051" src="https://github.com/user-attachments/assets/da420de4-da75-4ba1-8e67-3987f86b81ac" />

<img width="1919" height="990" alt="Screenshot 2026-07-19 175908" src="https://github.com/user-attachments/assets/e3edca5e-b8c6-4bda-a1a5-d014dac8aa34" />


For the addional emote trending/rank list:

When clicking on the weekly or top rank of a current emote, a list pops up showing the weekly trending emotes / top all-time ranked emotes (updates daily).

<img width="1910" height="988" alt="Screenshot 2026-07-21 223608" src="https://github.com/user-attachments/assets/dc5a7f84-ac45-49b7-a425-dd157e99e4a6" />

<img width="1914" height="984" alt="Screenshot 2026-07-21 223617" src="https://github.com/user-attachments/assets/22af145d-49d2-4b22-8933-7443bef06d8f" />


## Types of changes

- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation Update (if none of the other choices apply)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged