### PR TITLE
Add emote selection to reports

### DIFF
--- a/apps/website/src/components/dialogs/report-emote-dialog.svelte
+++ b/apps/website/src/components/dialogs/report-emote-dialog.svelte
@@ -7,6 +7,9 @@
 	import Radio from "../input/radio.svelte";
 	import { graphql } from "$/gql";
 	import Spinner from "../spinner.svelte";
+	import UserEmotesSearch from "../user-emotes-search.svelte";
+	import type { Emote } from "$/gql/graphql";
+	import { user } from "$/lib/auth";
 
 	const reasons = [
 		"dialogs.report_emote.reasons.my_work",
@@ -23,12 +26,18 @@
 	let reason = $state<string>();
 	let additionalInfo = $state("");
 
+	let originEmote = $state<Emote>();
+
 	let loading = $state(false);
 
 	async function submit() {
 		if (!reason) return;
 
 		loading = true;
+
+		if (originEmote && "id" in originEmote)
+			additionalInfo =
+				additionalInfo + " Original Emote: " + window.location.origin + "/emotes/" + originEmote.id;
 
 		const res = await gqlClient()
 			.mutation(
@@ -58,6 +67,10 @@
 			mode = "hidden";
 		}
 	}
+
+	$effect(() => {
+		if (mode == "hidden" || !reason || !reason.endsWith(".my_work")) originEmote = undefined;
+	});
 </script>
 
 <Dialog width={40} bind:mode>
@@ -74,6 +87,11 @@
 				</Radio>
 			{/each}
 		</div>
+		{#if typeof reason == "string" && reason.endsWith(".my_work") && $user}
+			<UserEmotesSearch userID={$user.id} bind:selected={originEmote}>
+				<span class="label">{$t("labels.original_emote")} <small>({$t("common.not_required")})</small></span>
+			</UserEmotesSearch>
+		{/if}
 		<TextInput type="textarea" placeholder={$t("labels.enter_text")} bind:value={additionalInfo}>
 			<span class="label">{$t("dialogs.report_emote.additional_info")}</span>
 		</TextInput>

--- a/apps/website/src/components/user-emotes-search.svelte
+++ b/apps/website/src/components/user-emotes-search.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+	import type { Emote, EmoteSearchResult, User } from "$/gql/graphql";
+	import { onMount, type ComponentProps, type Snippet } from "svelte";
+	import TextInput from "./input/text-input.svelte";
+	import { gql } from "@urql/svelte";
+	import { gqlClient } from "$/lib/gql";
+	import Button from "./input/button.svelte";
+	import ResponsiveImage from "./responsive-image.svelte";
+	import Spinner from "./spinner.svelte";
+	import { Smiley } from "phosphor-svelte";
+	import { t } from "svelte-i18n";
+
+	type Props = {
+		userID: string;
+		selected: Emote | undefined;
+		children?: Snippet;
+	} & ComponentProps<typeof TextInput>;
+
+	let { userID, selected = $bindable(), children, ...restProps }: Props = $props();
+
+	let userEmotes = $state<EmoteSearchResult>();
+	let searchInput = $state<string>("");
+
+	let results = $derived(userEmotes ? searchFilter() : null);
+
+	function searchFilter() {
+		if (!userEmotes || !userEmotes["items"]) return null;
+		if (!searchInput.length) return userEmotes["items"];
+
+		return userEmotes["items"].filter((emote) =>
+			emote.defaultName.toLowerCase().includes(searchInput.toLowerCase()),
+		);
+	}
+
+	async function load(): Promise<EmoteSearchResult> {
+		const variables = {
+			id: userID,
+		};
+
+		const gql_query = gql`
+			query UserOwnedEmotes($id: Id!) {
+				users {
+					user(id: $id) {
+						ownedEmotes {
+							id
+							defaultName
+							images {
+								url
+								mime
+								size
+								scale
+								width
+								frameCount
+							}
+						}
+					}
+				}
+			}
+		`;
+
+		const res = await gqlClient().query(gql_query, variables).toPromise();
+		if (res.error || !res.data) {
+			throw res.error;
+		}
+		const emotes = res.data.users.user?.ownedEmotes;
+		if (!emotes) {
+			throw new Error("No emotes found");
+		}
+		return {
+			items: emotes as Emote[],
+			totalCount: emotes.length,
+			pageCount: 1,
+		};
+	}
+
+	const bindEmote = (e: Emote) => {
+		selected = e;
+		searchInput = e.defaultName;
+	};
+
+	const clearValue = () => (selected = undefined);
+
+	onMount(async () => (userEmotes = await load()));
+</script>
+
+<TextInput
+	type="text"
+	{...restProps}
+	placeholder={$t("labels.search_emotes", { values: { count: 1 } })}
+	bind:value={searchInput}
+	oninput={clearValue}
+>
+	{#snippet icon()}
+		{#if !selected}
+			{#await userEmotes}
+				<Spinner />
+			{:then _}
+				<Smiley />
+			{/await}
+		{:else}
+			<!-- wrapped to prevent weird display -->
+			<span><ResponsiveImage images={selected.images} width={10 * 2} /></span>
+		{/if}
+	{/snippet}
+	{@render children?.()}
+	{#if results && results.length}
+		<div class="popup-results results">
+			{#each results as result}
+				<Button class="item" onclick={() => bindEmote(result)}>
+					{#snippet icon()}
+						<ResponsiveImage images={result.images} width={13 * 2} />
+					{/snippet}
+					{result.defaultName}
+				</Button>
+			{/each}
+		</div>
+	{/if}
+</TextInput>
+
+<style lang="scss">
+	:global(label.input:has(input:enabled)):focus-within > .popup-results {
+		display: flex;
+	}
+
+	span {
+		:global {
+			.image {
+				vertical-align: middle;
+			}
+		}
+	}
+
+	.popup-results {
+		position: absolute;
+		top: calc(100% + 0.25rem);
+		left: 0;
+		right: 0;
+		z-index: 10;
+
+		background-color: var(--bg-light);
+
+		border: 1px solid var(--border-active);
+		border-radius: 0.5rem;
+
+		display: none;
+		overflow-x: hidden;
+
+		flex-direction: column;
+
+		& > :global(.button) {
+			animation: expand-down 0.2s forwards;
+		}
+	}
+
+	.results {
+		max-height: 10rem;
+	}
+
+	@keyframes expand-down {
+		from {
+			height: 2rem;
+		}
+		to {
+			height: 2.75rem;
+		}
+	}
+</style>

--- a/apps/website/src/locales/en.json
+++ b/apps/website/src/locales/en.json
@@ -91,7 +91,8 @@
     "profile": "Profile",
     "pinned": "Pinned",
     "settings": "Settings",
-    "delete_account": "Delete Account"
+    "delete_account": "Delete Account",
+    "not_required": "Not Required"
   },
   "labels": {
     "enter_text": "Enter text",
@@ -104,6 +105,7 @@
     "search_user": "Search User",
     "search_country": "Search Country",
     "search_emote_set": "Search Emote Set",
+    "search_emotes": "{count, plural, one {Search an emote} other {Search emotes}}",
     "search_users": "{count, plural, one {Search a user} other {Search users}}",
     "tags": "Tags",
     "close": "Close",
@@ -149,7 +151,8 @@
     "remove": "Remove",
     "accept": "Accept",
     "deny": "Deny",
-    "enter": "Enter"
+    "enter": "Enter",
+    "original_emote": "Original Emote"
   },
   "themes": {
     "system": "System",


### PR DESCRIPTION
## Proposed changes

Adds a emote selector for "i made this emote" report.
Emote selector is not required to be set and its only using reporting user uploaded emotes.

I don't know rust, so I just made it add to a the report reason.

## Preview
<img width="1000" height="422" alt="2026-07-22_02-02" src="https://github.com/user-attachments/assets/44638baf-063a-461d-9464-99b9c75c3ead" />

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged
